### PR TITLE
feat: instrument with OpenTelemetry spans (JRL-11)

### DIFF
--- a/.syncpackrc.yaml
+++ b/.syncpackrc.yaml
@@ -1,17 +1,17 @@
 # syncpack config — enforce semver range consistency
 semverGroups:
-  - label: "Pinned pre-release versions"
+  - label: 'Pinned pre-release versions'
     dependencies:
-      - "@duckdb/duckdb-wasm"
-      - "@duckdb/duckdb-wasm-shell"
-    range: ""
-  - label: "Default — caret ranges"
+      - '@duckdb/duckdb-wasm'
+      - '@duckdb/duckdb-wasm-shell'
+    range: ''
+  - label: 'Default — caret ranges'
     dependencies:
-      - "**"
-    range: "^"
+      - '**'
+    range: '^'
 
 versionGroups:
-  - label: "Ignore example apps"
+  - label: 'Ignore example apps'
     packages:
-      - "@jr200-labs/xstate-duckdb-react-test"
+      - '@jr200-labs/xstate-duckdb-react-test'
     isIgnored: true

--- a/README.md
+++ b/README.md
@@ -77,16 +77,16 @@ nest correctly under any caller-provided parent span.
 
 ### Emitted spans
 
-| Span name                   | Emitted by                        | Attributes                                                             |
-| --------------------------- | --------------------------------- | ---------------------------------------------------------------------- |
-| `xstate.duckdb.init`        | `initDuckDb`                      | `duckdb.version`                                                       |
-| `xstate.duckdb.close`       | `closeDuckDb`                     | —                                                                      |
-| `xstate.duckdb.query`       | `duckdbRunQuery` / `queryDuckDb`  | `query.description`, `result.type`, `result.row_count`                 |
-| `xstate.duckdb.tx.begin`    | `beginTransaction`                | —                                                                      |
-| `xstate.duckdb.tx.commit`   | `commitTransaction`               | —                                                                      |
-| `xstate.duckdb.tx.rollback` | `rollbackTransaction`             | —                                                                      |
-| `xstate.duckdb.load_table`  | `loadTableIntoDuckDb`             | `table.spec`, `payload.type`, `payload.compression`, `table.instance`  |
-| `xstate.duckdb.prune`       | `pruneTableVersions`              | `pruned.instances`, `kept.versions`                                    |
+| Span name                   | Emitted by                       | Attributes                                                            |
+| --------------------------- | -------------------------------- | --------------------------------------------------------------------- |
+| `xstate.duckdb.init`        | `initDuckDb`                     | `duckdb.version`                                                      |
+| `xstate.duckdb.close`       | `closeDuckDb`                    | —                                                                     |
+| `xstate.duckdb.query`       | `duckdbRunQuery` / `queryDuckDb` | `query.description`, `result.type`, `result.row_count`                |
+| `xstate.duckdb.tx.begin`    | `beginTransaction`               | —                                                                     |
+| `xstate.duckdb.tx.commit`   | `commitTransaction`              | —                                                                     |
+| `xstate.duckdb.tx.rollback` | `rollbackTransaction`            | —                                                                     |
+| `xstate.duckdb.load_table`  | `loadTableIntoDuckDb`            | `table.spec`, `payload.type`, `payload.compression`, `table.instance` |
+| `xstate.duckdb.prune`       | `pruneTableVersions`             | `pruned.instances`, `kept.versions`                                   |
 
 All error paths record exceptions on the active span, set span status to
 `ERROR`, and emit an `xstate.duckdb.error` event with a truncated stack.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,54 @@ The `duckdbMachine` has the following states:
 - `CATALOG.DROP_TABLE`: Drop a table
 - `CATALOG.LIST_DEFINITIONS`: Get catalog configuration
 
+## OpenTelemetry
+
+This library emits OpenTelemetry spans for DuckDB lifecycle, query, transaction,
+and catalog operations. DuckDB runs in-process (WASM) so there is no cross-
+process context propagation — spans attach to the ambient OTel context so they
+nest correctly under any caller-provided parent span.
+
+### Emitted spans
+
+| Span name                   | Emitted by                        | Attributes                                                             |
+| --------------------------- | --------------------------------- | ---------------------------------------------------------------------- |
+| `xstate.duckdb.init`        | `initDuckDb`                      | `duckdb.version`                                                       |
+| `xstate.duckdb.close`       | `closeDuckDb`                     | —                                                                      |
+| `xstate.duckdb.query`       | `duckdbRunQuery` / `queryDuckDb`  | `query.description`, `result.type`, `result.row_count`                 |
+| `xstate.duckdb.tx.begin`    | `beginTransaction`                | —                                                                      |
+| `xstate.duckdb.tx.commit`   | `commitTransaction`               | —                                                                      |
+| `xstate.duckdb.tx.rollback` | `rollbackTransaction`             | —                                                                      |
+| `xstate.duckdb.load_table`  | `loadTableIntoDuckDb`             | `table.spec`, `payload.type`, `payload.compression`, `table.instance`  |
+| `xstate.duckdb.prune`       | `pruneTableVersions`              | `pruned.instances`, `kept.versions`                                    |
+
+All error paths record exceptions on the active span, set span status to
+`ERROR`, and emit an `xstate.duckdb.error` event with a truncated stack.
+
+### Enabling tracing
+
+`@opentelemetry/api` is a peer dependency — the consumer controls the installed
+version and registers the SDK. If no provider is registered all telemetry calls
+become no-ops. Minimal setup:
+
+```ts
+import { trace, propagation, context } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import { BasicTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+
+const provider = new BasicTracerProvider({
+  spanProcessors: [
+    /* your exporter */
+  ],
+})
+trace.setGlobalTracerProvider(provider)
+propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+
+const ctxMgr = new AsyncLocalStorageContextManager()
+ctxMgr.enable()
+context.setGlobalContextManager(ctxMgr)
+```
+
 ## Examples
 
 ### Basic Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jr200-labs/xstate-duckdb",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "XState machine for DuckDB",
   "license": "MIT",
   "author": "Jayshan Raghunandan",
@@ -48,9 +48,16 @@
     "pako": "^2.1.0",
     "xstate": "^5.30.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0"
+  },
   "devDependencies": {
     "@apache-arrow/ts": "^21.1.0",
     "@eslint/js": "^10.0.1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-async-hooks": "^2.7.0",
+    "@opentelemetry/core": "^2.7.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.0",
     "@statelyai/inspect": "^0.7.1",
     "@types/pako": "^2.0.4",
     "@vitest/coverage-v8": "^4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,18 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1(jiti@1.21.7))
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
       '@statelyai/inspect':
         specifier: ^0.7.1
         version: 0.7.1(xstate@5.30.0)
@@ -65,7 +77,7 @@ importers:
         version: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7))
 
   examples/react-test:
     dependencies:
@@ -618,6 +630,38 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.7.0':
+    resolution: {integrity: sha512-MWXggArM+Y11mPS8VOrqxOj+YMGQSRuvhM91eSBX4xFpJa05mpkeVvM8pPux5ElkEjV5RMgrkisrlP/R83SpBQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.0':
+    resolution: {integrity: sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.0':
+    resolution: {integrity: sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.0':
+    resolution: {integrity: sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -2489,6 +2533,32 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
@@ -2771,7 +2841,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -3828,7 +3898,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
 
-  vitest@4.1.4(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@24.12.2)(jiti@1.21.7))
@@ -3851,6 +3921,7 @@ snapshots:
       vite: 6.4.2(@types/node@24.12.2)(jiti@1.21.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.2
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:

--- a/src/actors/dbCatalog.ts
+++ b/src/actors/dbCatalog.ts
@@ -2,6 +2,7 @@ import { fromPromise } from 'xstate/actors'
 import { JSONObject, TableDefinition, LoadedTableEntry } from '../lib/types'
 import { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import pako from 'pako'
+import { withSpan } from '../telemetry'
 
 export interface LoadTableInput {
   nextTableId: number
@@ -12,53 +13,65 @@ export interface LoadTableInput {
 }
 
 export const loadTableIntoDuckDb = fromPromise(async ({ input }: any) => {
-  try {
-    const { nextTableId, payloadType, tableDefinitions, payloadCompression } = input
-    const tableDefinition = findTableDefinition(input.tableSpecName, tableDefinitions)
-    if (!tableDefinition) {
-      input.callback?.({ error: `Table definition for table ${input.tableSpecName} not found` })
-      return
-    }
+  return withSpan(
+    'xstate.duckdb.load_table',
+    'xstate.duckdb.error',
+    {
+      'table.spec': input.tableSpecName,
+      'payload.type': input.payloadType,
+      'payload.compression': input.payloadCompression,
+    },
+    async (span) => {
+      try {
+        const { nextTableId, payloadType, tableDefinitions, payloadCompression } = input
+        const tableDefinition = findTableDefinition(input.tableSpecName, tableDefinitions)
+        if (!tableDefinition) {
+          input.callback?.({ error: `Table definition for table ${input.tableSpecName} not found` })
+          return
+        }
 
-    const tableNameInstance = makeTableNameInstance(tableDefinition, nextTableId)
-    const catalogEntry: LoadedTableEntry = {
-      tableIsVersioned: tableDefinition.isVersioned,
-      tableVersionId: nextTableId,
-      tableSpecName: tableDefinition.name,
-      tableInstanceName: tableNameInstance,
-      loadedEpoch: Date.now(),
-    }
-    let result: any
+        const tableNameInstance = makeTableNameInstance(tableDefinition, nextTableId)
+        span.setAttribute('table.instance', tableNameInstance)
+        const catalogEntry: LoadedTableEntry = {
+          tableIsVersioned: tableDefinition.isVersioned,
+          tableVersionId: nextTableId,
+          tableSpecName: tableDefinition.name,
+          tableInstanceName: tableNameInstance,
+          loadedEpoch: Date.now(),
+        }
+        let result: any
 
-    const dbConnection = await input.duckDbHandle.connect()
-    if (payloadType === 'json') {
-      result = await loadTableFromJson(
-        tableDefinition.isVersioned,
-        tableDefinition.schema,
-        tableNameInstance,
-        input.tablePayload,
-        dbConnection,
-        payloadCompression,
-      )
-    } else if (payloadType === 'b64ipc') {
-      result = await loadTableFromB64ipc(
-        tableDefinition.isVersioned,
-        tableDefinition.schema,
-        tableNameInstance,
-        input.tablePayload,
-        dbConnection,
-        payloadCompression,
-      )
-    } else {
-      result = { error: `Unknown payload type: ${payloadType}` }
-    }
+        const dbConnection = await input.duckDbHandle.connect()
+        if (payloadType === 'json') {
+          result = await loadTableFromJson(
+            tableDefinition.isVersioned,
+            tableDefinition.schema,
+            tableNameInstance,
+            input.tablePayload,
+            dbConnection,
+            payloadCompression,
+          )
+        } else if (payloadType === 'b64ipc') {
+          result = await loadTableFromB64ipc(
+            tableDefinition.isVersioned,
+            tableDefinition.schema,
+            tableNameInstance,
+            input.tablePayload,
+            dbConnection,
+            payloadCompression,
+          )
+        } else {
+          result = { error: `Unknown payload type: ${payloadType}` }
+        }
 
-    input.callback?.(tableNameInstance, result.error)
-    return catalogEntry
-  } catch (error: any) {
-    input.callback?.({ error: error.message })
-    return { error: error.message }
-  }
+        input.callback?.(tableNameInstance, result.error)
+        return catalogEntry
+      } catch (error: any) {
+        input.callback?.({ error: error.message })
+        return { error: error.message }
+      }
+    },
+  )
 })
 
 function findTableDefinition(tableSpecName: string, definitions: TableDefinition[]) {
@@ -121,37 +134,43 @@ async function loadTableFromB64ipc(
 }
 
 export const pruneTableVersions = fromPromise(async ({ input }: any) => {
-  const currentLoadedVersions: LoadedTableEntry[] = input.currentLoadedVersions
-  const definitions: TableDefinition[] = input.tableDefinitions
-  const dbConnection = await input.duckDbHandle.connect()
-  await dbConnection.query(`BEGIN TRANSACTION;`)
+  return withSpan('xstate.duckdb.prune', 'xstate.duckdb.error', {}, async (span) => {
+    const currentLoadedVersions: LoadedTableEntry[] = input.currentLoadedVersions
+    const definitions: TableDefinition[] = input.tableDefinitions
+    const dbConnection = await input.duckDbHandle.connect()
+    await dbConnection.query(`BEGIN TRANSACTION;`)
 
-  try {
-    let prunedLoadedVersions: LoadedTableEntry[] = []
-    for (const definition of definitions) {
-      const { isVersioned, name, maxVersions } = definition
-      const loadedTables = currentLoadedVersions
-        .filter((loadedTbl) => loadedTbl.tableSpecName === name)
-        .sort((a, b) => b.tableVersionId - a.tableVersionId)
+    try {
+      let prunedLoadedVersions: LoadedTableEntry[] = []
+      let prunedInstances = 0
+      for (const definition of definitions) {
+        const { isVersioned, name, maxVersions } = definition
+        const loadedTables = currentLoadedVersions
+          .filter((loadedTbl) => loadedTbl.tableSpecName === name)
+          .sort((a, b) => b.tableVersionId - a.tableVersionId)
 
-      const versionsToKeep = loadedTables.slice(0, maxVersions)
-      if (isVersioned) {
-        const tableInstancesToPrune = loadedTables
-          .slice(maxVersions)
-          .map((tbl) => tbl.tableInstanceName)
-        await dropTables(tableInstancesToPrune, dbConnection)
+        const versionsToKeep = loadedTables.slice(0, maxVersions)
+        if (isVersioned) {
+          const tableInstancesToPrune = loadedTables
+            .slice(maxVersions)
+            .map((tbl) => tbl.tableInstanceName)
+          prunedInstances += tableInstancesToPrune.length
+          await dropTables(tableInstancesToPrune, dbConnection)
+        }
+        prunedLoadedVersions = [...prunedLoadedVersions, ...versionsToKeep]
       }
-      prunedLoadedVersions = [...prunedLoadedVersions, ...versionsToKeep]
+
+      await dbConnection.query(`COMMIT;`)
+      span.setAttribute('pruned.instances', prunedInstances)
+      span.setAttribute('kept.versions', prunedLoadedVersions.length)
+
+      return { loadedVersions: prunedLoadedVersions }
+    } catch (error: any) {
+      console.error('Error pruning table versions', error)
+      await dbConnection.query(`ROLLBACK;`)
+      return { error: error.message }
     }
-
-    await dbConnection.query(`COMMIT;`)
-
-    return { loadedVersions: prunedLoadedVersions }
-  } catch (error: any) {
-    console.error('Error pruning table versions', error)
-    await dbConnection.query(`ROLLBACK;`)
-    return { error: error.message }
-  }
+  })
 })
 
 export const dropTables = async (tableInstances: string[], connection: AsyncDuckDBConnection) => {

--- a/src/actors/dbInit.ts
+++ b/src/actors/dbInit.ts
@@ -1,49 +1,55 @@
 import { fromPromise } from 'xstate'
 import { AsyncDuckDB, ConsoleLogger, getJsDelivrBundles, selectBundle } from '@duckdb/duckdb-wasm'
 import { InitDuckDbParams } from '../lib/types'
+import { withSpan } from '../telemetry'
 
 export const initDuckDb = fromPromise(async ({ input }: { input: InitDuckDbParams }) => {
-  const bundles = getJsDelivrBundles()
-  const bundle = await selectBundle(bundles)
+  return withSpan('xstate.duckdb.init', 'xstate.duckdb.error', {}, async (span) => {
+    const bundles = getJsDelivrBundles()
+    const bundle = await selectBundle(bundles)
 
-  const workerUrl = URL.createObjectURL(
-    new Blob([`importScripts("${bundle.mainWorker!}");`], {
-      type: 'text/javascript',
-    }),
-  )
+    const workerUrl = URL.createObjectURL(
+      new Blob([`importScripts("${bundle.mainWorker!}");`], {
+        type: 'text/javascript',
+      }),
+    )
 
-  const worker = new Worker(workerUrl)
-  const db = new AsyncDuckDB(new ConsoleLogger(input.dbLogLevel), worker)
+    const worker = new Worker(workerUrl)
+    const db = new AsyncDuckDB(new ConsoleLogger(input.dbLogLevel), worker)
 
-  input.statusHandler?.('initializing')
-  await db.instantiate(
-    bundle.mainModule,
-    bundle.pthreadWorker,
-    input.dbProgressHandler ?? undefined,
-  )
-  URL.revokeObjectURL(workerUrl)
+    input.statusHandler?.('initializing')
+    await db.instantiate(
+      bundle.mainModule,
+      bundle.pthreadWorker,
+      input.dbProgressHandler ?? undefined,
+    )
+    URL.revokeObjectURL(workerUrl)
 
-  if (input.dbInitParams) {
-    console.debug('initDuckDb with config', input.dbInitParams)
-    await db.open(input.dbInitParams)
-  }
+    if (input.dbInitParams) {
+      console.debug('initDuckDb with config', input.dbInitParams)
+      await db.open(input.dbInitParams)
+    }
 
-  const version = await db.getVersion()
+    const version = await db.getVersion()
+    span.setAttribute('duckdb.version', version)
 
-  input.statusHandler?.('ready')
+    input.statusHandler?.('ready')
 
-  return {
-    db,
-    version,
-  }
+    return {
+      db,
+      version,
+    }
+  })
 })
 
 export const closeDuckDb = fromPromise(async ({ input }: { input: { db: AsyncDuckDB | null } }) => {
-  if (input.db) {
-    await input.db.terminate()
-  }
+  return withSpan('xstate.duckdb.close', 'xstate.duckdb.error', {}, async () => {
+    if (input.db) {
+      await input.db.terminate()
+    }
 
-  return {
-    db: null,
-  }
+    return {
+      db: null,
+    }
+  })
 })

--- a/src/actors/dbQuery.ts
+++ b/src/actors/dbQuery.ts
@@ -10,6 +10,7 @@ import {
   arrayToFirstValue,
   arrayToFirstRowMap,
 } from '../lib/utils'
+import { withSpan } from '../telemetry'
 
 export interface ResultOptions {
   key?: string
@@ -47,19 +48,33 @@ type DuckDbQueryResult =
 export async function duckdbRunQuery(
   input: QueryDbParams & { connection: AsyncDuckDBConnection },
 ): Promise<DuckDbQueryResult | void> {
-  const sql = input.sql as string
-  const raw =
-    input.resultOptions?.type === 'arrow'
-      ? await duckDbExecuteToArrow(input.description, sql, input.connection)
-      : await duckDbExecuteToJson(input.description, sql, input.connection)
+  return withSpan(
+    'xstate.duckdb.query',
+    'xstate.duckdb.error',
+    {
+      'query.description': input.description,
+      'result.type': input.resultOptions?.type,
+    },
+    async (span) => {
+      const sql = input.sql as string
+      const raw =
+        input.resultOptions?.type === 'arrow'
+          ? await duckDbExecuteToArrow(input.description, sql, input.connection)
+          : await duckDbExecuteToJson(input.description, sql, input.connection)
 
-  const result = formatResult(raw, input.resultOptions)
+      if (Array.isArray(raw)) {
+        span.setAttribute('result.row_count', raw.length)
+      }
 
-  if (input.callback) {
-    input.callback(result)
-  } else {
-    return result
-  }
+      const result = formatResult(raw, input.resultOptions)
+
+      if (input.callback) {
+        input.callback(result)
+        return undefined
+      }
+      return result
+    },
+  )
 }
 
 function formatResult(
@@ -148,20 +163,26 @@ async function duckDbExecuteToJson(
 
 export const beginTransaction = fromPromise(
   async ({ input }: { input: AsyncDuckDB }): Promise<AsyncDuckDBConnection> => {
-    const connection = await input.connect()
-    await connection.query('BEGIN TRANSACTION;')
-    return connection
+    return withSpan('xstate.duckdb.tx.begin', 'xstate.duckdb.error', {}, async () => {
+      const connection = await input.connect()
+      await connection.query('BEGIN TRANSACTION;')
+      return connection
+    })
   },
 )
 
 export const commitTransaction = fromPromise(
   async ({ input }: { input: AsyncDuckDBConnection }): Promise<void> => {
-    await input.query('COMMIT;')
+    return withSpan('xstate.duckdb.tx.commit', 'xstate.duckdb.error', {}, async () => {
+      await input.query('COMMIT;')
+    })
   },
 )
 
 export const rollbackTransaction = fromPromise(
   async ({ input }: { input: AsyncDuckDBConnection }): Promise<void> => {
-    await input.query('ROLLBACK;')
+    return withSpan('xstate.duckdb.tx.rollback', 'xstate.duckdb.error', {}, async () => {
+      await input.query('ROLLBACK;')
+    })
   },
 )

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,99 @@
+// OpenTelemetry helpers scoped to this package.
+//
+// `@opentelemetry/api` is declared as a peer dependency so the consumer
+// controls the installed version. If the consumer never registers a
+// TracerProvider, every call here becomes a no-op.
+//
+// Unlike `@jr200-labs/xstate-nats`, this package has no cross-process
+// boundary to propagate through — DuckDB-WASM runs in the same JS VM — so we
+// only emit spans and do not inject/extract W3C trace context headers.
+
+import type { Span, Tracer } from '@opentelemetry/api'
+import { context as otelContext, SpanStatusCode, trace } from '@opentelemetry/api'
+import pkg from '../package.json' with { type: 'json' }
+
+const TRACER_NAME = '@jr200-labs/xstate-duckdb'
+
+// Do not cache — `trace.getTracer` already returns a lightweight ProxyTracer,
+// and caching across global-provider swaps (e.g. test teardown / re-register)
+// would pin the delegate to a retired provider and silently lose spans.
+export function getTracer(): Tracer {
+  return trace.getTracer(TRACER_NAME, pkg.version)
+}
+
+// Truncate the stack trace before attaching it to a span event. Some backends
+// (and the wire format itself) perform poorly with arbitrarily long strings;
+// the first ~1KB is almost always enough to identify the site.
+const MAX_STACK_LEN = 1024
+
+function truncateStack(err: unknown): string | undefined {
+  if (!(err instanceof Error) || !err.stack) return undefined
+  return err.stack.length > MAX_STACK_LEN
+    ? err.stack.slice(0, MAX_STACK_LEN) + '...(truncated)'
+    : err.stack
+}
+
+/**
+ * Record an error on a span using the OTel canonical pattern:
+ * recordException + ERROR status + a named event with the truncated stack.
+ */
+export function recordError(span: Span, errorEventName: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err)
+  if (err instanceof Error) {
+    span.recordException(err)
+  }
+  span.setStatus({ code: SpanStatusCode.ERROR, message })
+  const stack = truncateStack(err)
+  span.addEvent(errorEventName, stack ? { stack } : undefined)
+}
+
+/**
+ * Run `fn` inside an active span. On synchronous throw or async rejection the
+ * error is recorded, the span status is set to ERROR, and the error is
+ * re-thrown (callers keep their existing error-handling semantics).
+ */
+export function withSpan<T>(
+  name: string,
+  errorEventName: string,
+  attributes: Record<string, string | number | boolean | undefined>,
+  fn: (span: Span) => T | Promise<T>,
+): T | Promise<T> {
+  const tracer = getTracer()
+  const sanitized = sanitizeAttributes(attributes)
+  return tracer.startActiveSpan(name, { attributes: sanitized }, otelContext.active(), (span) => {
+    try {
+      const result = fn(span)
+      if (result && typeof (result as Promise<T>).then === 'function') {
+        return (result as Promise<T>).then(
+          (value) => {
+            span.end()
+            return value
+          },
+          (err: unknown) => {
+            recordError(span, errorEventName, err)
+            span.end()
+            throw err
+          },
+        ) as unknown as T
+      }
+      span.end()
+      return result
+    } catch (err) {
+      recordError(span, errorEventName, err)
+      span.end()
+      throw err
+    }
+  })
+}
+
+// OTel attributes cannot be `undefined`; strip those so call sites can pass
+// optional values without a pre-filter.
+function sanitizeAttributes(
+  attrs: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+  const out: Record<string, string | number | boolean> = {}
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v !== undefined) out[k] = v
+  }
+  return out
+}

--- a/tests/actors.telemetry.test.ts
+++ b/tests/actors.telemetry.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpanStatusCode } from '@opentelemetry/api'
+import { createActor } from 'xstate'
+import { setupInMemoryTracer, type OtelTestHarness } from './otel-setup'
+import {
+  beginTransaction,
+  commitTransaction,
+  rollbackTransaction,
+  queryDuckDb,
+  duckdbRunQuery,
+} from '../src/actors/dbQuery'
+import { closeDuckDb } from '../src/actors/dbInit'
+
+function createMockConnection() {
+  return {
+    query: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as any
+}
+
+function createMockDb() {
+  const connection = createMockConnection()
+  return {
+    db: {
+      connect: vi.fn().mockResolvedValue(connection),
+      terminate: vi.fn().mockResolvedValue(undefined),
+    } as any,
+    connection,
+  }
+}
+
+async function runActor<T>(actor: ReturnType<typeof createActor>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    actor.subscribe({
+      next: (snap) => {
+        if (snap.status === 'done') resolve(snap.output as T)
+      },
+      error: (err) => reject(err),
+    })
+    actor.start()
+  })
+}
+
+describe('actor telemetry', () => {
+  let harness: OtelTestHarness
+
+  beforeEach(() => {
+    harness = setupInMemoryTracer()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    harness.teardown()
+    vi.restoreAllMocks()
+  })
+
+  it('beginTransaction emits xstate.duckdb.tx.begin span', async () => {
+    const { db, connection } = createMockDb()
+    const actor = createActor(beginTransaction, { input: db })
+    await runActor(actor)
+
+    expect(connection.query).toHaveBeenCalledWith('BEGIN TRANSACTION;')
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans.find((s) => s.name === 'xstate.duckdb.tx.begin')).toBeDefined()
+  })
+
+  it('commitTransaction emits xstate.duckdb.tx.commit span', async () => {
+    const connection = createMockConnection()
+    const actor = createActor(commitTransaction, { input: connection })
+    await runActor(actor)
+
+    expect(connection.query).toHaveBeenCalledWith('COMMIT;')
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans.find((s) => s.name === 'xstate.duckdb.tx.commit')).toBeDefined()
+  })
+
+  it('rollbackTransaction emits xstate.duckdb.tx.rollback span', async () => {
+    const connection = createMockConnection()
+    const actor = createActor(rollbackTransaction, { input: connection })
+    await runActor(actor)
+
+    expect(connection.query).toHaveBeenCalledWith('ROLLBACK;')
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans.find((s) => s.name === 'xstate.duckdb.tx.rollback')).toBeDefined()
+  })
+
+  it('closeDuckDb emits xstate.duckdb.close span', async () => {
+    const { db } = createMockDb()
+    const actor = createActor(closeDuckDb, { input: { db } })
+    await runActor(actor)
+
+    expect(db.terminate).toHaveBeenCalled()
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans.find((s) => s.name === 'xstate.duckdb.close')).toBeDefined()
+  })
+
+  it('closeDuckDb is a no-op but still emits span when db is null', async () => {
+    const actor = createActor(closeDuckDb, { input: { db: null } })
+    await runActor(actor)
+
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans.find((s) => s.name === 'xstate.duckdb.close')).toBeDefined()
+  })
+
+  it('duckdbRunQuery emits xstate.duckdb.query span with description attr', async () => {
+    const connection = {
+      query: vi.fn().mockResolvedValue({ numRows: 0 } as any),
+    } as any
+
+    await duckdbRunQuery({
+      description: 'my-query',
+      sql: 'SELECT 1',
+      resultOptions: { type: 'arrow' },
+      connection,
+      callback: vi.fn(),
+    })
+
+    const spans = harness.exporter.getFinishedSpans()
+    const qs = spans.find((s) => s.name === 'xstate.duckdb.query')
+    expect(qs).toBeDefined()
+    expect(qs!.attributes['query.description']).toBe('my-query')
+    expect(qs!.attributes['result.type']).toBe('arrow')
+  })
+
+  it('beginTransaction records error and sets ERROR status on rejection', async () => {
+    const connection = {
+      query: vi.fn().mockRejectedValue(new Error('tx failed')),
+    } as any
+    const db = {
+      connect: vi.fn().mockResolvedValue(connection),
+    } as any
+
+    const actor = createActor(beginTransaction, { input: db })
+    await expect(runActor(actor)).rejects.toThrow('tx failed')
+
+    const spans = harness.exporter.getFinishedSpans()
+    const txSpan = spans.find((s) => s.name === 'xstate.duckdb.tx.begin')!
+    expect(txSpan.status.code).toBe(SpanStatusCode.ERROR)
+    expect(txSpan.events.some((e) => e.name === 'xstate.duckdb.error')).toBe(true)
+  })
+})

--- a/tests/otel-setup.ts
+++ b/tests/otel-setup.ts
@@ -1,0 +1,51 @@
+// Shared OpenTelemetry test harness.
+//
+// Registers an in-memory exporter so span emission can be asserted without a
+// real backend. The global TracerProvider / ContextManager are reset between
+// tests to keep cases isolated.
+
+import { context, propagation, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { W3CTraceContextPropagator } from '@opentelemetry/core'
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base'
+
+export interface OtelTestHarness {
+  exporter: InMemorySpanExporter
+  provider: BasicTracerProvider
+  reset: () => void
+  teardown: () => void
+}
+
+// sdk-trace-base v2 removed `provider.register()`; wire up the global tracer
+// provider, propagator, and context manager directly through the API package.
+// Without the context manager, `startActiveSpan` would run the callback but
+// never attach the span to `context.active()` — which would silently lose the
+// parent/child relationship.
+export function setupInMemoryTracer(): OtelTestHarness {
+  const exporter = new InMemorySpanExporter()
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  })
+  const ctxMgr = new AsyncLocalStorageContextManager()
+  ctxMgr.enable()
+  context.setGlobalContextManager(ctxMgr)
+  trace.setGlobalTracerProvider(provider)
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator())
+
+  return {
+    exporter,
+    provider,
+    reset: () => exporter.reset(),
+    teardown: () => {
+      trace.disable()
+      propagation.disable()
+      context.disable()
+      ctxMgr.disable()
+      void provider.shutdown()
+    },
+  }
+}

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { SpanStatusCode } from '@opentelemetry/api'
+import { setupInMemoryTracer, type OtelTestHarness } from './otel-setup'
+import { withSpan, recordError } from '../src/telemetry'
+
+describe('telemetry helpers', () => {
+  let harness: OtelTestHarness
+
+  beforeEach(() => {
+    harness = setupInMemoryTracer()
+  })
+
+  afterEach(() => {
+    harness.teardown()
+  })
+
+  it('withSpan emits a span on sync success', () => {
+    const result = withSpan('test.sync', 'test.error', { foo: 'bar' }, () => 42)
+    expect(result).toBe(42)
+
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0].name).toBe('test.sync')
+    expect(spans[0].attributes.foo).toBe('bar')
+    expect(spans[0].status.code).not.toBe(SpanStatusCode.ERROR)
+  })
+
+  it('withSpan emits a span on async success', async () => {
+    const result = await withSpan('test.async', 'test.error', {}, async () => 'done')
+    expect(result).toBe('done')
+
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans[0].name).toBe('test.async')
+    expect(spans[0].status.code).not.toBe(SpanStatusCode.ERROR)
+  })
+
+  it('withSpan records error on sync throw and re-throws', () => {
+    expect(() =>
+      withSpan('test.throw', 'test.error', {}, () => {
+        throw new Error('boom')
+      }),
+    ).toThrow('boom')
+
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans[0].status.code).toBe(SpanStatusCode.ERROR)
+    expect(spans[0].events.some((e) => e.name === 'test.error')).toBe(true)
+  })
+
+  it('withSpan records error on async rejection and re-throws', async () => {
+    await expect(
+      withSpan('test.reject', 'test.error', {}, async () => {
+        throw new Error('nope')
+      }),
+    ).rejects.toThrow('nope')
+
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans[0].status.code).toBe(SpanStatusCode.ERROR)
+  })
+
+  it('withSpan drops undefined attribute values', () => {
+    withSpan('test.attrs', 'test.error', { a: 'x', b: undefined, c: 0 }, () => null)
+
+    const spans = harness.exporter.getFinishedSpans()
+    expect(spans[0].attributes.a).toBe('x')
+    expect(spans[0].attributes.c).toBe(0)
+    expect('b' in spans[0].attributes).toBe(false)
+  })
+
+  it('recordError truncates stacks longer than 1KB', () => {
+    withSpan('test.bigstack', 'test.error', {}, (span) => {
+      const err = new Error('big')
+      err.stack = 'x'.repeat(2000)
+      recordError(span, 'test.error', err)
+    })
+
+    const spans = harness.exporter.getFinishedSpans()
+    const event = spans[0].events.find((e) => e.name === 'test.error')!
+    expect((event.attributes?.stack as string).length).toBeLessThan(1100)
+    expect((event.attributes?.stack as string).endsWith('...(truncated)')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds OpenTelemetry span emission for DuckDB lifecycle, query, transaction, and catalog operations
- `@opentelemetry/api` is a peer dep — no-ops when the consumer hasn't registered a provider
- Bumps version to 0.4.0

## Spans

| Span name | Emitted by |
| --- | --- |
| `xstate.duckdb.init` / `xstate.duckdb.close` | `initDuckDb` / `closeDuckDb` |
| `xstate.duckdb.query` | `duckdbRunQuery` / `queryDuckDb` |
| `xstate.duckdb.tx.begin` / `.commit` / `.rollback` | transaction actors |
| `xstate.duckdb.load_table` | `loadTableIntoDuckDb` |
| `xstate.duckdb.prune` | `pruneTableVersions` |

Error paths record exceptions, set span status to `ERROR`, and emit `xstate.duckdb.error` with a truncated stack.

DuckDB runs in-process (WASM) so there is no cross-process context propagation — spans attach to the ambient OTel context and nest under any caller-provided parent span.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test` (110 passing, 2 new suites: `telemetry.test.ts`, `actors.telemetry.test.ts`)
- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm syncpack lint` clean