### PR TITLE
fix(deps): widen @duckdb/duckdb-wasm range off exact dev prerelease

### DIFF
--- a/.syncpackrc.yaml
+++ b/.syncpackrc.yaml
@@ -1,10 +1,5 @@
 # syncpack config — enforce semver range consistency
 semverGroups:
-  - label: 'Pinned pre-release versions'
-    dependencies:
-      - '@duckdb/duckdb-wasm'
-      - '@duckdb/duckdb-wasm-shell'
-    range: ''
   - label: 'Default — caret ranges'
     dependencies:
       - '**'

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "state-machine"
   ],
   "dependencies": {
-    "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
+    "@duckdb/duckdb-wasm": "^1.33.1-dev42.0",
     "apache-arrow": "^21.1.0",
     "duckdb-wasm-kit": "^0.1.39",
     "pako": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@duckdb/duckdb-wasm':
-        specifier: 1.33.1-dev45.0
+        specifier: ^1.33.1-dev42.0
         version: 1.33.1-dev45.0
       apache-arrow:
         specifier: ^21.1.0


### PR DESCRIPTION
## Summary

- Declared `@duckdb/duckdb-wasm` at the exact version `1.33.1-dev45.0`. Because xstate-duckdb is pulled in transitively by consumer bundles, that exact pin forced every consumer onto 1.33.1-dev45.0 regardless of what they pinned themselves — leading to two copies of duckdb-wasm in the bundle whenever a consumer pinned a different known-good prerelease.
- Widen to `^1.33.1-dev42.0` so known-good prereleases, stable 1.33.x, and later minors all resolve normally.
- Consumers retain full control via their direct pin or pnpm `overrides`.

## Test plan

- [x] `pnpm install --lockfile-only` regenerates cleanly
- [x] `rm -rf node_modules && pnpm install --frozen-lockfile` verifies the lockfile
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (110 / 110)
- [ ] CI green