### PR TITLE
chore: sync canonical release-please config and changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,13 @@
 
 ## [0.5.1](https://github.com/jr200-labs/xstate-duckdb/compare/v0.5.0...v0.5.1) (2026-04-23)
 
-
 ### Bug Fixes
 
-* **deps:** widen @duckdb/duckdb-wasm range off exact dev prerelease ([#18](https://github.com/jr200-labs/xstate-duckdb/issues/18)) ([836453f](https://github.com/jr200-labs/xstate-duckdb/commit/836453fbfcfb912255d50f5bb39c499db0bb2887))
+- **deps:** widen @duckdb/duckdb-wasm range off exact dev prerelease ([#18](https://github.com/jr200-labs/xstate-duckdb/issues/18)) ([836453f](https://github.com/jr200-labs/xstate-duckdb/commit/836453fbfcfb912255d50f5bb39c499db0bb2887))
 
 ## [0.5.0](https://github.com/jr200-labs/xstate-duckdb/compare/v0.4.0...v0.5.0) (2026-04-22)
 
-
 ### Features
 
-* adopt release-please + generic sync.sh ([ceabb7d](https://github.com/jr200-labs/xstate-duckdb/commit/ceabb7d296a83150f6cb3b9e81970db930650f4d))
-* adopt release-please + generic sync.sh ([c104aa3](https://github.com/jr200-labs/xstate-duckdb/commit/c104aa32dd626be8ba69f823055540eddbf3d542))
+- adopt release-please + generic sync.sh ([ceabb7d](https://github.com/jr200-labs/xstate-duckdb/commit/ceabb7d296a83150f6cb3b9e81970db930650f4d))
+- adopt release-please + generic sync.sh ([c104aa3](https://github.com/jr200-labs/xstate-duckdb/commit/c104aa32dd626be8ba69f823055540eddbf3d542))

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Pulls in drift from https://github.com/jr200-labs/github-action-templates/blob/master/shared/release-please-config.json that the pre-commit sync step repeatedly rewrote locally but was never committed.

- `release-please-config.json` adds `"bump-minor-pre-major": true` and `"bump-patch-for-minor-pre-major": true`. During 0.x these make `fix:` commits bump patch (0.5.1 -> 0.5.2) and `feat:` commits bump minor (0.5.x -> 0.6.0) predictably instead of the default 0.x behavior. Matches canonical template.
- `CHANGELOG.md` cosmetic bullet style `*` -> `-` from canonical prettier config.

No runtime change for consumers of `@jr200-labs/xstate-duckdb`.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (110/110)
- [ ] Next `fix:` commit on master generates a patch-level release PR (verified once it triggers)