### PR TITLE
feat!: move @duckdb/duckdb-wasm and apache-arrow to peerDependencies

### DIFF
--- a/.syncpackrc.yaml
+++ b/.syncpackrc.yaml
@@ -6,6 +6,13 @@ semverGroups:
     range: '^'
 
 versionGroups:
+  - label: 'Peer ranges — broader than dev install pins by design'
+    dependencyTypes:
+      - 'peer'
+    dependencies:
+      - '@duckdb/duckdb-wasm'
+      - 'apache-arrow'
+    isIgnored: true
   - label: 'Ignore example apps'
     packages:
       - '@jr200-labs/xstate-duckdb-react-test'

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ yarn add @jr200-labs/xstate-duckdb
 pnpm add @jr200-labs/xstate-duckdb
 ```
 
+### Peer dependencies
+
+`@duckdb/duckdb-wasm`, `apache-arrow`, and `@opentelemetry/api` are declared as peer dependencies and must be installed directly by the consumer. This guarantees a single resolved version across the dependency tree -- preventing the class of bug where a transitive copy of DuckDB-wasm diverges from the `.wasm` assets the consumer actually ships.
+
+```bash
+pnpm add @duckdb/duckdb-wasm apache-arrow @opentelemetry/api
+```
+
+Supported ranges:
+
+| Peer                  | Range                 |
+| --------------------- | --------------------- |
+| `@duckdb/duckdb-wasm` | `>=1.33.1-dev42.0 <2` |
+| `apache-arrow`        | `>=21 <22`            |
+| `@opentelemetry/api`  | `^1.9.0`              |
+
 ## API Reference
 
 ### Machine States

--- a/package.json
+++ b/package.json
@@ -42,17 +42,18 @@
     "state-machine"
   ],
   "dependencies": {
-    "@duckdb/duckdb-wasm": "^1.33.1-dev42.0",
-    "apache-arrow": "^21.1.0",
     "duckdb-wasm-kit": "^0.1.39",
     "pako": "^2.1.0",
     "xstate": "^5.30.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0"
+    "@duckdb/duckdb-wasm": ">=1.33.1-dev42.0 <2",
+    "@opentelemetry/api": "^1.9.0",
+    "apache-arrow": ">=21 <22"
   },
   "devDependencies": {
     "@apache-arrow/ts": "^21.1.0",
+    "@duckdb/duckdb-wasm": "^1.33.1-dev42.0",
     "@eslint/js": "^10.0.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^2.7.0",
@@ -61,6 +62,7 @@
     "@statelyai/inspect": "^0.7.1",
     "@types/pako": "^2.0.4",
     "@vitest/coverage-v8": "^4.1.4",
+    "apache-arrow": "^21.1.0",
     "eslint": "^10.2.1",
     "globals": "^17.5.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@duckdb/duckdb-wasm':
-        specifier: ^1.33.1-dev42.0
-        version: 1.33.1-dev45.0
-      apache-arrow:
-        specifier: ^21.1.0
-        version: 21.1.0
       duckdb-wasm-kit:
         specifier: ^0.1.39
         version: 0.1.39(@duckdb/duckdb-wasm@1.33.1-dev45.0)(apache-arrow@21.1.0)(react@19.2.5)
@@ -27,6 +21,9 @@ importers:
       '@apache-arrow/ts':
         specifier: ^21.1.0
         version: 21.1.0
+      '@duckdb/duckdb-wasm':
+        specifier: ^1.33.1-dev42.0
+        version: 1.33.1-dev45.0
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1(jiti@1.21.7))
@@ -51,6 +48,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
+      apache-arrow:
+        specifier: ^21.1.0
+        version: 21.1.0
       eslint:
         specifier: ^10.2.1
         version: 10.2.1(jiti@1.21.7)


### PR DESCRIPTION
Fixes [JRL-29](https://linear.app/jr200-labs/issue/JRL-29).

## Summary

Move `@duckdb/duckdb-wasm` and `apache-arrow` from `dependencies` to `peerDependencies`. Consumers now declare and own the version directly; pnpm/npm enforce a single resolved copy in the tree.

## Why

Between 2026-04-13 and 2026-04-22, `@jr200-labs/xstate-duckdb@0.4.0` and `0.5.0` shipped with an exact pin of `@duckdb/duckdb-wasm@1.33.1-dev45.0` as a regular `dependencies`. dev45 rewrote the HTTPWasmClient fetch path (upstream commit `0c09da6`) and broke module instantiation with `Body is disturbed or locked`. Consumers like `whengas-ui@v0.3.11` pinned dev42 in their own `package.json` but the transitive `xstate-atoms -> xstate-duckdb -> dev45` chain silently dragged the broken version into the tree. Fixed symptomatically in https://github.com/jr200-labs/xstate-duckdb/pull/18 by widening the range to `^1.33.1-dev42.0`; this PR is the structural fix.

With duckdb-wasm as a `peerDependency`:

- Only one copy in the tree. JS and `.wasm` assets can no longer diverge.
- Consumer owns the version choice. Renovate bumps land in the consumer's `package.json` where they are reviewable, not in a transitive lockfile entry.
- Install-time failure. pnpm/npm warn loudly if the consumer's pin does not satisfy the peer range. Silent drag-in becomes impossible.
- The `pnpm.overrides` block and `.syncpackrc.yaml` exact-pin in https://github.com/whengas/whengas-ui can be retired.

`duckdb-wasm-kit` already declares both as peerDeps, so the whole chain is now consistent.

## Changes

- `package.json`: move `@duckdb/duckdb-wasm` and `apache-arrow` to `peerDependencies`; keep them under `devDependencies` so local tests and `examples/react-test` still install.
- `.syncpackrc.yaml`: add a `versionGroup` that ignores consistency between `dev` and `peer` declarations for these two packages. Intentional -- peer is a compatibility range, dev is a reproducible install pin.
- `README.md`: add a "Peer dependencies" section documenting the consumer contract and the supported ranges.

## Peer ranges

| Peer                  | Range                 |
| --------------------- | --------------------- |
| `@duckdb/duckdb-wasm` | `>=1.33.1-dev42.0 <2` |
| `apache-arrow`        | `>=21 <22`            |
| `@opentelemetry/api`  | `^1.9.0` (unchanged)  |

Ranges are explicit `>=` / `<` rather than caret, because caret with prereleases is too strict.

## Release target

**0.6.0 minor**, not 1.0. Conventional-commit `feat!:` with `BREAKING CHANGE:` footer; `release-please-config.json` has `bump-minor-pre-major: true` and defaults `bump-major-pre-major: false`, so a breaking change during 0.x generates a minor bump and a prominent "BREAKING CHANGES" CHANGELOG section. Not yet committing to 1.0 semver.

## Follow-up PRs (separate, tracked on JRL-29)

- `xstate-atoms`: propagate peer treatment for `@duckdb/duckdb-wasm` + `apache-arrow`; release as minor.
- `whengas-ui`: consume new atoms, drop `pnpm.overrides` and the `@duckdb/duckdb-wasm*` entries from `.syncpackrc.yaml`.
- https://github.com/jr200-labs/github-action-templates: once the above lands, remove the duckdb-wasm `review-by: 2026-05-23` pin-lint entry from `default.json`.

## Test plan

- [x] `pnpm install` clean (no peer warnings in this repo's own dev tree)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (110/110)
- [x] `pnpm syncpack lint` passes (verifies the new versionGroup is valid)
- [x] `pnpm build` succeeds
- [ ] After release: verify consumer install hits a peer warning if duckdb-wasm is not in their `package.json` (manual smoke in a throwaway app)
- [ ] After release: verify `xstate-atoms` + `whengas-ui` upgrade chain works end-to-end