### PR TITLE
ci: grant permissions + wire workflow-runners lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,12 @@ on:
     branches: [master]
   workflow_dispatch:
 
+# Required by the ci_npmjs.yaml reusable workflow's size-limit job
+# (gated on `run-size-limit` but permissions are validated upfront).
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   ci:
     uses: jr200-labs/github-action-templates/.github/workflows/ci_npmjs.yaml@master
@@ -15,3 +21,6 @@ jobs:
 
   commitlint:
     uses: jr200-labs/github-action-templates/.github/workflows/lint_commits.yaml@master
+
+  lint-workflow-runners:
+    uses: jr200-labs/github-action-templates/.github/workflows/lint_workflow_runners.yaml@master


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read / pull-requests: write` — `ci_npmjs.yaml`'s size-limit job declares job-level `pull-requests: write` which reusable-workflow permissions-cascade validates against the caller's top-level permissions *before* any `if:` gate runs. Without this block CI fails with `startup_failure` on every PR.
- Wires the new shared `lint_workflow_runners.yaml` from jr200-labs/github-action-templates#64 so any hardcoded `runs-on: ubuntu-latest` gets caught at PR time (org is on self-hosted via `vars.RUNNER_PROFILE`).

## Test plan

- [ ] CI goes green (unit + commitlint + lint-workflow-runners all pass, no startup_failure)