### PR TITLE
chore: enable npm package publishing

### DIFF
--- a/.github/.shared-config.yaml
+++ b/.github/.shared-config.yaml
@@ -1,5 +1,6 @@
-ref: shared-v0.1.0
+ref: shared-v0.1.2
 workflows:
   - hygiene
   - node
   - release
+  - npm-package

--- a/.github/workflows/publish-npm-package.yaml
+++ b/.github/workflows/publish-npm-package.yaml
@@ -1,0 +1,48 @@
+# GENERATED/SHARED WORKFLOW: copied into consuming repos by sync-shared.
+# Do not edit in consuming repos; change jr200-labs/github-action-templates and sync.
+name: publish-npm-package
+
+# Triggered by release-please publishing a tag. Builds and publishes the
+# package to npmjs.com via pnpm publish. Verbatim across consumers; each
+# consumer must set the NPMJS_API_TOKEN secret.
+
+on:
+  repository_dispatch:
+    types: [release-published]
+  workflow_dispatch:
+    inputs:
+      checkout-ref:
+        description: "checkout ref"
+        required: false
+        type: string
+        default: "refs/heads/master"
+      pnpm-run-test:
+        description: "Run pnpm test:run before publish"
+        required: false
+        type: string
+        default: "true"
+      pnpm-publish-args:
+        description: "Additional pnpm publish args"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  configure:
+    uses: jr200-labs/github-action-templates/.github/workflows/preconfigure.yaml@master
+    with:
+      event_name: ${{ toJson(github.event_name) }}
+      event: ${{ toJson(github.event) }}
+
+  main:
+    needs: configure
+    uses: jr200-labs/github-action-templates/.github/workflows/build_publish_npmjs.yaml@master
+    with:
+      checkout-ref: ${{ fromJson(needs.configure.outputs.context).checkout-ref }}
+      pnpm-run-test: ${{ github.event.inputs.pnpm-run-test || 'true' }}
+      pnpm-publish-args: ${{ github.event.inputs.pnpm-publish-args || '' }}
+    secrets:
+      npmjs_api_token: ${{ secrets.NPMJS_API_TOKEN }}


### PR DESCRIPTION
## Summary
- bump shared workflow pin to shared-v0.1.2
- add the npm-package shared workflow group
- sync the generated publish-npm-package workflow from shared-v0.1.2

## Verification
- ./scripts/sync-shared
- ./scripts/sync-shared --check