### PR TITLE
feat: track duckdb load metrics

### DIFF
--- a/src/actors/dbCatalog.ts
+++ b/src/actors/dbCatalog.ts
@@ -3,6 +3,7 @@ import { JSONObject, TableDefinition, LoadedTableEntry } from '../lib/types'
 import { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import pako from 'pako'
 import { withSpan } from '../telemetry'
+import { byteLength, DuckDbLoadMetricRecord } from '../loadMetrics'
 
 export interface LoadTableInput {
   nextTableId: number
@@ -10,6 +11,11 @@ export interface LoadTableInput {
   payloadCompression: 'none' | 'zlib'
   tableDefinitions: TableDefinition[]
   callback: (tableInstanceName: string, error?: string) => void
+}
+
+type LoadTableResult = {
+  error?: null | string
+  loadMetrics: DuckDbLoadMetricRecord
 }
 
 export const loadTableIntoDuckDb = fromPromise(async ({ input }: any) => {
@@ -39,12 +45,13 @@ export const loadTableIntoDuckDb = fromPromise(async ({ input }: any) => {
           tableInstanceName: tableNameInstance,
           loadedEpoch: Date.now(),
         }
-        let result: any
+        let result: LoadTableResult
 
         const dbConnection = await input.duckDbHandle.connect()
         if (payloadType === 'json') {
           result = await loadTableFromJson(
             tableDefinition.isVersioned,
+            tableDefinition.name,
             tableDefinition.schema,
             tableNameInstance,
             input.tablePayload,
@@ -54,6 +61,7 @@ export const loadTableIntoDuckDb = fromPromise(async ({ input }: any) => {
         } else if (payloadType === 'b64ipc') {
           result = await loadTableFromB64ipc(
             tableDefinition.isVersioned,
+            tableDefinition.name,
             tableDefinition.schema,
             tableNameInstance,
             input.tablePayload,
@@ -61,11 +69,25 @@ export const loadTableIntoDuckDb = fromPromise(async ({ input }: any) => {
             payloadCompression,
           )
         } else {
-          result = { error: `Unknown payload type: ${payloadType}` }
+          result = {
+            error: `Unknown payload type: ${payloadType}`,
+            loadMetrics: {
+              tableSpecName: tableDefinition.name,
+              encodedBytes: 0,
+              decodedBytes: 0,
+              loadedBytes: 0,
+            },
+          }
         }
 
+        span.setAttribute('payload.encoded_bytes', result.loadMetrics.encodedBytes)
+        span.setAttribute('payload.decoded_bytes', result.loadMetrics.decodedBytes)
+        span.setAttribute('payload.loaded_bytes', result.loadMetrics.loadedBytes)
         input.callback?.(tableNameInstance, result.error)
-        return catalogEntry
+        return {
+          ...catalogEntry,
+          loadMetrics: result.loadMetrics,
+        }
       } catch (error: any) {
         input.callback?.({ error: error.message })
         return { error: error.message }
@@ -86,24 +108,34 @@ function makeTableNameInstance(definition: TableDefinition, nextTableId: number)
 }
 async function loadTableFromJson(
   tableIsVersioned: boolean,
+  tableSpecName: string,
   tableSchema: string,
   tableName: string,
   jsonPayload: JSONObject,
-  dbConnection: AsyncDuckDBConnection,
-  compression: 'none' | 'zlib',
-): Promise<any> {
+  _dbConnection: AsyncDuckDBConnection,
+  _compression: 'none' | 'zlib',
+): Promise<LoadTableResult> {
   console.log('loadTableFromJson', tableName, jsonPayload, tableIsVersioned)
-  return { tableSchema, tableName, dbConnection, compression, jsonPayload }
+  const bytes = byteLength(jsonPayload)
+  return {
+    loadMetrics: {
+      tableSpecName,
+      encodedBytes: bytes,
+      decodedBytes: bytes,
+      loadedBytes: bytes,
+    },
+  }
 }
 
 async function loadTableFromB64ipc(
   tableIsVersioned: boolean,
+  tableSpecName: string,
   tableSchema: string,
   tableName: string,
   base64ipc: string,
   connection: AsyncDuckDBConnection,
   compression: 'none' | 'zlib',
-): Promise<any> {
+): Promise<LoadTableResult> {
   // const msgSizeMb = base64ipc.length / 1024 / 1024
 
   const binaryString = window.atob(base64ipc)
@@ -114,6 +146,12 @@ async function loadTableFromB64ipc(
 
   // Decompress with pako if zlib compression is enabled
   const finalByteArray = compression === 'zlib' ? pako.inflate(byteArray) : byteArray
+  const loadMetrics = {
+    tableSpecName,
+    encodedBytes: byteLength(base64ipc),
+    decodedBytes: byteArray.byteLength,
+    loadedBytes: finalByteArray.byteLength,
+  }
 
   try {
     if (!tableIsVersioned) {
@@ -127,10 +165,10 @@ async function loadTableFromB64ipc(
     })
   } catch (error: any) {
     console.error('Error loading table from b64ipc', error)
-    return { result: 'error', error: error }
+    return { error, loadMetrics }
   }
 
-  return { result: 'ok', error: null }
+  return { error: null, loadMetrics }
 }
 
 export const pruneTableVersions = fromPromise(async ({ input }: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,14 @@ export type {
 } from './lib/types'
 
 export { duckdbRunQuery, type QueryDbParams, type ResultOptions } from './actors/dbQuery'
+export {
+  byteLength as duckDbLoadMetricByteLength,
+  createEmptyDuckDbLoadMetrics,
+  recordDuckDbLoadMetric,
+  resetDuckDbLoadMetrics,
+  type DuckDbLoadMetricBucket,
+  type DuckDbLoadMetricRecord,
+  type DuckDbLoadMetrics,
+} from './loadMetrics'
 
 export type DuckDbCatalogSnapshot = SnapshotFrom<typeof dbCatalogLogic>

--- a/src/loadMetrics.test.ts
+++ b/src/loadMetrics.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  byteLength,
+  createEmptyDuckDbLoadMetrics,
+  recordDuckDbLoadMetric,
+  resetDuckDbLoadMetrics,
+} from './loadMetrics'
+
+describe('DuckDB load metrics', () => {
+  it('counts UTF-8 bytes for strings and JSON payloads', () => {
+    expect(byteLength('hello')).toBe(5)
+    expect(byteLength({ value: 'hello' })).toBe(17)
+  })
+
+  it('records totals and per-table load metrics', () => {
+    const metrics = recordDuckDbLoadMetric(createEmptyDuckDbLoadMetrics(), {
+      tableSpecName: 'cargos',
+      encodedBytes: 12,
+      decodedBytes: 9,
+      loadedBytes: 120,
+    })
+
+    expect(metrics.encodedBytes).toBe(12)
+    expect(metrics.decodedBytes).toBe(9)
+    expect(metrics.loadedBytes).toBe(120)
+    expect(metrics.byTable.cargos).toEqual({
+      encodedBytes: 12,
+      decodedBytes: 9,
+      loadedBytes: 120,
+    })
+  })
+
+  it('resets all metrics or one table', () => {
+    const metrics = recordDuckDbLoadMetric(
+      recordDuckDbLoadMetric(createEmptyDuckDbLoadMetrics(), {
+        tableSpecName: 'cargos',
+        encodedBytes: 12,
+        decodedBytes: 9,
+        loadedBytes: 120,
+      }),
+      {
+        tableSpecName: 'vectors',
+        encodedBytes: 8,
+        decodedBytes: 6,
+        loadedBytes: 60,
+      },
+    )
+
+    expect(resetDuckDbLoadMetrics(metrics, 'cargos')).toEqual({
+      encodedBytes: 8,
+      decodedBytes: 6,
+      loadedBytes: 60,
+      byTable: {
+        vectors: {
+          encodedBytes: 8,
+          decodedBytes: 6,
+          loadedBytes: 60,
+        },
+      },
+    })
+    expect(resetDuckDbLoadMetrics(metrics)).toEqual(createEmptyDuckDbLoadMetrics())
+  })
+})

--- a/src/loadMetrics.ts
+++ b/src/loadMetrics.ts
@@ -1,0 +1,93 @@
+export interface DuckDbLoadMetricBucket {
+  encodedBytes: number
+  decodedBytes: number
+  loadedBytes: number
+}
+
+export interface DuckDbLoadMetrics extends DuckDbLoadMetricBucket {
+  byTable: Partial<Record<string, DuckDbLoadMetricBucket>>
+}
+
+export interface DuckDbLoadMetricRecord extends DuckDbLoadMetricBucket {
+  tableSpecName: string
+}
+
+export function createEmptyDuckDbLoadMetrics(): DuckDbLoadMetrics {
+  return {
+    encodedBytes: 0,
+    decodedBytes: 0,
+    loadedBytes: 0,
+    byTable: {},
+  }
+}
+
+export function recordDuckDbLoadMetric(
+  metrics: DuckDbLoadMetrics,
+  record: DuckDbLoadMetricRecord,
+): DuckDbLoadMetrics {
+  const encodedBytes = normaliseByteCount(record.encodedBytes)
+  const decodedBytes = normaliseByteCount(record.decodedBytes)
+  const loadedBytes = normaliseByteCount(record.loadedBytes)
+  if (encodedBytes === 0 && decodedBytes === 0 && loadedBytes === 0) return metrics
+
+  const currentTable = metrics.byTable[record.tableSpecName] ?? {
+    encodedBytes: 0,
+    decodedBytes: 0,
+    loadedBytes: 0,
+  }
+
+  return {
+    encodedBytes: metrics.encodedBytes + encodedBytes,
+    decodedBytes: metrics.decodedBytes + decodedBytes,
+    loadedBytes: metrics.loadedBytes + loadedBytes,
+    byTable: {
+      ...metrics.byTable,
+      [record.tableSpecName]: {
+        encodedBytes: currentTable.encodedBytes + encodedBytes,
+        decodedBytes: currentTable.decodedBytes + decodedBytes,
+        loadedBytes: currentTable.loadedBytes + loadedBytes,
+      },
+    },
+  }
+}
+
+export function resetDuckDbLoadMetrics(
+  metrics: DuckDbLoadMetrics,
+  tableSpecName?: string,
+): DuckDbLoadMetrics {
+  if (!tableSpecName) return createEmptyDuckDbLoadMetrics()
+
+  const tableMetrics = metrics.byTable[tableSpecName]
+  if (!tableMetrics) return metrics
+
+  const byTable = { ...metrics.byTable }
+  delete byTable[tableSpecName]
+
+  return {
+    encodedBytes: metrics.encodedBytes - tableMetrics.encodedBytes,
+    decodedBytes: metrics.decodedBytes - tableMetrics.decodedBytes,
+    loadedBytes: metrics.loadedBytes - tableMetrics.loadedBytes,
+    byTable,
+  }
+}
+
+const textEncoder = new TextEncoder()
+
+export function byteLength(value: unknown): number {
+  if (value == null) return 0
+  if (value instanceof Uint8Array) return value.byteLength
+  if (value instanceof ArrayBuffer) return value.byteLength
+  if (ArrayBuffer.isView(value)) return value.byteLength
+  if (typeof value === 'string') return textEncoder.encode(value).byteLength
+
+  try {
+    return textEncoder.encode(JSON.stringify(value)).byteLength
+  } catch {
+    return 0
+  }
+}
+
+function normaliseByteCount(value: number | undefined): number {
+  if (!Number.isFinite(value) || value === undefined || value <= 0) return 0
+  return Math.floor(value)
+}

--- a/src/machines/dbCatalog.ts
+++ b/src/machines/dbCatalog.ts
@@ -2,6 +2,13 @@ import { assign, setup } from 'xstate'
 import { TableDefinition, LoadedTableEntry, CatalogSubscription } from '../lib/types'
 import { loadTableIntoDuckDb, pruneTableVersions } from '../actors/dbCatalog'
 import { AsyncDuckDB } from '@duckdb/duckdb-wasm'
+import {
+  createEmptyDuckDbLoadMetrics,
+  DuckDbLoadMetricRecord,
+  DuckDbLoadMetrics,
+  recordDuckDbLoadMetric,
+  resetDuckDbLoadMetrics,
+} from '../loadMetrics'
 
 export interface TableLoadEvent {
   tableSpecName: string
@@ -15,9 +22,14 @@ export interface TableLoadEventInternal extends TableLoadEvent {
   duckDbHandle: AsyncDuckDB | null
 }
 
+type LoadedTableWithMetrics = LoadedTableEntry & {
+  loadMetrics?: DuckDbLoadMetricRecord
+}
+
 export interface Context {
   tableDefinitions: TableDefinition[]
   loadedVersions: Array<LoadedTableEntry>
+  loadMetrics: DuckDbLoadMetrics
   subscriptions: Map<string, CatalogSubscription>
   nextTableId: number
   pendingTableLoads: TableLoadEventInternal[]
@@ -28,6 +40,7 @@ export interface Context {
 type ExternalEvents =
   // these events are used to reset the catalog
   | { type: 'CATALOG.RESET' }
+  | { type: 'CATALOG.METRICS.RESET_LOADS'; tableSpecName?: string }
   | { type: 'CATALOG.CONFIGURE'; tableDefinitions: TableDefinition[] }
   | { type: 'CATALOG.CONNECT' }
   | { type: 'CATALOG.DISCONNECT' }
@@ -74,6 +87,7 @@ export const dbCatalogLogic = setup({
   context: {
     tableDefinitions: [],
     loadedVersions: [],
+    loadMetrics: createEmptyDuckDbLoadMetrics(),
     subscriptions: new Map<string, CatalogSubscription>(),
     nextTableId: 1,
     pendingTableLoads: [],
@@ -123,6 +137,13 @@ export const dbCatalogLogic = setup({
         event.callback(context.tableDefinitions)
       },
     },
+
+    'CATALOG.METRICS.RESET_LOADS': {
+      actions: assign({
+        loadMetrics: ({ context, event }) =>
+          resetDuckDbLoadMetrics(context.loadMetrics, event.tableSpecName),
+      }),
+    },
   },
 
   states: {
@@ -146,6 +167,7 @@ export const dbCatalogLogic = setup({
           actions: assign(() => ({
             config: [],
             loadedVersions: [],
+            loadMetrics: createEmptyDuckDbLoadMetrics(),
             subscriptions: new Map<string, CatalogSubscription>(),
             pendingTableLoads: [],
             currentTableLoad: null,
@@ -227,8 +249,11 @@ export const dbCatalogLogic = setup({
         onDone: {
           target: 'pruning_versions',
           actions: assign(({ event, context }) => {
-            const loadedTable = event.output as LoadedTableEntry
+            const loadedTable = event.output as LoadedTableWithMetrics
             const newLoadedVersions = [loadedTable, ...context.loadedVersions]
+            const nextLoadMetrics = loadedTable.loadMetrics
+              ? recordDuckDbLoadMetric(context.loadMetrics, loadedTable.loadMetrics)
+              : context.loadMetrics
 
             // Notify subscribers about the new table
             for (const [_, subscription] of context.subscriptions.entries()) {
@@ -244,6 +269,7 @@ export const dbCatalogLogic = setup({
             return {
               nextTableId: context.nextTableId + 1,
               loadedVersions: newLoadedVersions,
+              loadMetrics: nextLoadMetrics,
             }
           }),
         },

--- a/tests/actors/dbCatalog.test.ts
+++ b/tests/actors/dbCatalog.test.ts
@@ -64,6 +64,12 @@ describe('loadTableIntoDuckDb', () => {
     expect(result.tableInstanceName).toBe('users_5')
     expect(result.tableIsVersioned).toBe(true)
     expect(result.tableVersionId).toBe(5)
+    expect(result.loadMetrics).toEqual({
+      tableSpecName: 'users',
+      encodedBytes: 16,
+      decodedBytes: 16,
+      loadedBytes: 16,
+    })
     expect(callback).toHaveBeenCalledWith('users_5', undefined)
   })
 
@@ -151,6 +157,12 @@ describe('loadTableIntoDuckDb', () => {
     })
 
     expect(result.tableSpecName).toBe('users')
+    expect(result.loadMetrics).toEqual({
+      tableSpecName: 'users',
+      encodedBytes: 12,
+      decodedBytes: 9,
+      loadedBytes: 9,
+    })
     expect(mockInsertArrowFromIPCStream).toHaveBeenCalled()
     expect(callback).toHaveBeenCalledWith('users_1', null)
   })

--- a/tests/machines/dbCatalog.integration.test.ts
+++ b/tests/machines/dbCatalog.integration.test.ts
@@ -11,6 +11,16 @@ const mockLoadedEntry: LoadedTableEntry = {
   loadedEpoch: Date.now(),
 }
 
+const mockLoadedEntryWithMetrics = {
+  ...mockLoadedEntry,
+  loadMetrics: {
+    tableSpecName: 'test',
+    encodedBytes: 12,
+    decodedBytes: 9,
+    loadedBytes: 120,
+  },
+}
+
 function createTestMachine(
   loadResult: LoadedTableEntry = mockLoadedEntry,
   pruneResult?: { loadedVersions: LoadedTableEntry[] },
@@ -42,9 +52,23 @@ function waitForState(actor: any, targetState: string, timeout = 3000): Promise<
   })
 }
 
+function waitForCondition(actor: any, condition: () => boolean, timeout = 3000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out waiting for condition')), timeout)
+    const check = () => {
+      if (condition()) {
+        clearTimeout(timer)
+        resolve()
+      }
+    }
+    check()
+    actor.subscribe(() => check())
+  })
+}
+
 describe('actual dbCatalogLogic with mocked actors', () => {
   it('starts in idle state', () => {
-    const machine = createTestMachine()
+    const machine = createTestMachine(mockLoadedEntryWithMetrics)
     const actor = createActor(machine)
     actor.start()
     expect(actor.getSnapshot().value).toBe('idle')
@@ -52,7 +76,7 @@ describe('actual dbCatalogLogic with mocked actors', () => {
   })
 
   it('idle -> configured -> connected', () => {
-    const machine = createTestMachine()
+    const machine = createTestMachine(mockLoadedEntryWithMetrics)
     const actor = createActor(machine)
     actor.start()
 
@@ -68,7 +92,7 @@ describe('actual dbCatalogLogic with mocked actors', () => {
   })
 
   it('processes CATALOG.LOAD_TABLE through loading_table -> pruning_versions -> connected', async () => {
-    const machine = createTestMachine()
+    const machine = createTestMachine(mockLoadedEntryWithMetrics)
     const actor = createActor(machine)
     actor.start()
 
@@ -89,10 +113,30 @@ describe('actual dbCatalogLogic with mocked actors', () => {
       duckDbHandle: {},
     } as any)
 
-    await waitForState(actor, 'connected')
+    await waitForCondition(actor, () => actor.getSnapshot().context.nextTableId === 2)
 
     expect(actor.getSnapshot().context.loadedVersions).toHaveLength(1)
+    expect(actor.getSnapshot().context.loadMetrics).toEqual({
+      encodedBytes: 12,
+      decodedBytes: 9,
+      loadedBytes: 120,
+      byTable: {
+        test: {
+          encodedBytes: 12,
+          decodedBytes: 9,
+          loadedBytes: 120,
+        },
+      },
+    })
     expect(actor.getSnapshot().context.nextTableId).toBe(2)
+
+    actor.send({ type: 'CATALOG.METRICS.RESET_LOADS', tableSpecName: 'test' })
+    expect(actor.getSnapshot().context.loadMetrics).toEqual({
+      encodedBytes: 0,
+      decodedBytes: 0,
+      loadedBytes: 0,
+      byTable: {},
+    })
     actor.stop()
   })
 


### PR DESCRIPTION
## Summary
- add DuckDB load metric helpers for encoded, decoded, and loaded byte counts
- record load metrics from catalog table loads, including decompressed IPC payload size
- expose resettable load metrics on the catalog machine context

## Tests
- pnpm lint
- pnpm test
- pnpm build