### PR TITLE
fix: support pako 3 ESM exports

### DIFF
--- a/src/actors/dbCatalog.ts
+++ b/src/actors/dbCatalog.ts
@@ -1,7 +1,7 @@
 import { fromPromise } from 'xstate/actors'
 import { JSONObject, TableDefinition, LoadedTableEntry } from '../lib/types'
 import { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
-import pako from 'pako'
+import * as pako from 'pako'
 import { withSpan } from '../telemetry'
 import { byteLength, DuckDbLoadMetricRecord } from '../loadMetrics'
 

--- a/tests/actors/dbCatalog.test.ts
+++ b/tests/actors/dbCatalog.test.ts
@@ -13,9 +13,7 @@ const mockConnect = vi.fn().mockResolvedValue({
 })
 
 vi.mock('pako', () => ({
-  default: {
-    inflate: vi.fn((data: Uint8Array) => data),
-  },
+  inflate: vi.fn((data: Uint8Array) => data),
 }))
 
 // Mock window.atob for b64ipc decoding
@@ -221,7 +219,7 @@ describe('loadTableIntoDuckDb', () => {
       actor.start()
     })
 
-    const pako = (await import('pako')).default
+    const pako = await import('pako')
     expect(pako.inflate).toHaveBeenCalled()
   })
 


### PR DESCRIPTION
pako 3 no longer exposes a default export. Use its named module exports so Vite builds consumers successfully.