### PR TITLE
feat: add optimistic operation telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,13 @@ nest correctly under any caller-provided parent span.
 | `xstate.duckdb.tx.rollback`          | `rollbackTransaction`            | —                                                                     |
 | `xstate.duckdb.load_table`           | `loadTableIntoDuckDb`            | `table.spec`, `payload.type`, `payload.compression`, `table.instance` |
 | `xstate.duckdb.prune`                | `pruneTableVersions`             | `pruned.instances`, `kept.versions`                                   |
-| `xstate.duckdb.optimistic_operation` | `executeOptimisticOperation`     | `operation.action`                                                    |
+| `xstate.duckdb.optimistic_operation` | `executeOptimisticOperation`     | `operation.action`, `operation.outcome`                               |
+
+Optimistic operations also emit the low-cardinality counter
+`xstate.duckdb.optimistic.operation.count`, the millisecond histogram
+`xstate.duckdb.optimistic.operation.duration`, and a trace-correlated structured
+log for each accepted or rejected local operation. SQL and field values are
+never included.
 
 All error paths record exceptions on the active span, set span status to
 `ERROR`, and emit an `xstate.duckdb.error` event with a truncated stack.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "peerDependencies": {
     "@duckdb/duckdb-wasm": ">=1.33.1-dev42.0 <2",
     "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": ">=0.200.0 <1",
     "apache-arrow": ">=21 <22"
   },
   "devDependencies": {
@@ -55,6 +56,7 @@
     "@duckdb/duckdb-wasm": "^1.33.1-dev42.0",
     "@eslint/js": "^10.0.1",
     "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.220.0",
     "@opentelemetry/context-async-hooks": "^2.9.0",
     "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@duckdb/duckdb-wasm": ">=1.33.1-dev42.0 <2",
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/api-logs": ">=0.200.0 <1",
+    "@opentelemetry/api-logs": "^0.220.0",
     "apache-arrow": ">=21 <22"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
+      '@opentelemetry/api-logs':
+        specifier: ^0.220.0
+        version: 0.220.0
       '@opentelemetry/context-async-hooks':
         specifier: ^2.9.0
         version: 2.9.0(@opentelemetry/api@1.9.1)
@@ -486,6 +489,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -2640,6 +2647,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.1': {}
 

--- a/src/optimisticOperations.ts
+++ b/src/optimisticOperations.ts
@@ -1,5 +1,7 @@
 import type { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
-import { withSpan } from './telemetry'
+import { context as otelContext, SpanStatusCode } from '@opentelemetry/api'
+import { SeverityNumber } from '@opentelemetry/api-logs'
+import { getLogger, getMeter, getTracer } from './telemetry'
 
 export type OptimisticOperationAction = 'ack' | 'begin' | 'reconcile' | 'reject' | 'unknown'
 
@@ -154,15 +156,39 @@ export function executeOptimisticOperation(
   action: OptimisticOperationAction,
   sql: string,
 ): Promise<void> {
-  return Promise.resolve(
-    withSpan(
-      'xstate.duckdb.optimistic_operation',
-      'xstate.duckdb.error',
-      { 'operation.action': action },
-      async () => {
+  return getTracer().startActiveSpan(
+    'xstate.duckdb.optimistic_operation',
+    { attributes: { 'operation.action': action } },
+    async (span) => {
+      const started = performance.now()
+      let outcome = 'accepted'
+      try {
         await connection.query(sql)
-      },
-    ),
+      } catch (error) {
+        outcome = 'rejected'
+        span.setStatus({ code: SpanStatusCode.ERROR, message: 'optimistic operation failed' })
+        span.setAttribute('error.type', error instanceof Error ? error.name : 'unknown')
+        span.addEvent('xstate.duckdb.error')
+        throw error
+      } finally {
+        const duration = performance.now() - started
+        const attributes = { 'operation.action': action, 'operation.outcome': outcome }
+        span.setAttribute('operation.outcome', outcome)
+        getMeter().createCounter('xstate.duckdb.optimistic.operation.count').add(1, attributes)
+        getMeter()
+          .createHistogram('xstate.duckdb.optimistic.operation.duration', { unit: 'ms' })
+          .record(duration, attributes)
+        getLogger().emit({
+          eventName: 'xstate.duckdb.optimistic_operation',
+          severityNumber: outcome === 'accepted' ? SeverityNumber.INFO : SeverityNumber.ERROR,
+          severityText: outcome === 'accepted' ? 'INFO' : 'ERROR',
+          body: 'Optimistic DuckDB operation completed',
+          attributes: { ...attributes, 'duration.ms': duration },
+          context: otelContext.active(),
+        })
+        span.end()
+      }
+    },
   )
 }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -8,8 +8,10 @@
 // boundary to propagate through — DuckDB-WASM runs in the same JS VM — so we
 // only emit spans and do not inject/extract W3C trace context headers.
 
-import type { Span, Tracer } from '@opentelemetry/api'
-import { context as otelContext, SpanStatusCode, trace } from '@opentelemetry/api'
+import type { Meter, Span, Tracer } from '@opentelemetry/api'
+import { context as otelContext, metrics, SpanStatusCode, trace } from '@opentelemetry/api'
+import type { Logger } from '@opentelemetry/api-logs'
+import { logs } from '@opentelemetry/api-logs'
 import pkg from '../package.json' with { type: 'json' }
 
 const TRACER_NAME = '@jr200-labs/xstate-duckdb'
@@ -19,6 +21,14 @@ const TRACER_NAME = '@jr200-labs/xstate-duckdb'
 // would pin the delegate to a retired provider and silently lose spans.
 export function getTracer(): Tracer {
   return trace.getTracer(TRACER_NAME, pkg.version)
+}
+
+export function getMeter(): Meter {
+  return metrics.getMeter(TRACER_NAME, pkg.version)
+}
+
+export function getLogger(): Logger {
+  return logs.getLogger(TRACER_NAME, pkg.version)
 }
 
 // Truncate the stack trace before attaching it to a span event. Some backends

--- a/tests/optimisticOperations.telemetry.test.ts
+++ b/tests/optimisticOperations.telemetry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const telemetry = vi.hoisted(() => ({
+  add: vi.fn(),
+  emit: vi.fn(),
+  end: vi.fn(),
+  record: vi.fn(),
+  setAttribute: vi.fn(),
+  setStatus: vi.fn(),
+}))
+
+vi.mock('../src/telemetry', () => ({
+  getLogger: () => ({ emit: telemetry.emit }),
+  getMeter: () => ({
+    createCounter: () => ({ add: telemetry.add }),
+    createHistogram: () => ({ record: telemetry.record }),
+  }),
+  getTracer: () => ({
+    startActiveSpan: (_name: string, _options: unknown, callback: (span: unknown) => unknown) =>
+      callback({
+        addEvent: vi.fn(),
+        end: telemetry.end,
+        setAttribute: telemetry.setAttribute,
+        setStatus: telemetry.setStatus,
+      }),
+  }),
+}))
+
+import { executeOptimisticOperation } from '../src/optimisticOperations'
+
+describe('optimistic operation telemetry', () => {
+  it('emits low-cardinality telemetry after a local operation', async () => {
+    const query = vi.fn().mockResolvedValue(undefined)
+
+    await executeOptimisticOperation({ query } as never, 'begin', 'sensitive sql')
+
+    expect(telemetry.setAttribute).toHaveBeenCalledWith('operation.outcome', 'accepted')
+    expect(telemetry.add).toHaveBeenCalledWith(1, {
+      'operation.action': 'begin',
+      'operation.outcome': 'accepted',
+    })
+    expect(telemetry.record).toHaveBeenCalledOnce()
+    expect(telemetry.emit).toHaveBeenCalledOnce()
+    expect(JSON.stringify(telemetry.emit.mock.calls)).not.toContain('sensitive sql')
+    expect(telemetry.end).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary
- emit spans, low-cardinality metrics, and trace-correlated logs for optimistic operations
- record action, outcome, and duration without including SQL or field values
- document and test the telemetry contract

## Verification
- pnpm lint
- pnpm test
- pnpm build