### PR TITLE
fix: tolerate sparse optimistic source schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export {
   createOptimisticOperationsTableSql,
   createOptimisticOperationUnknownSql,
   createOptimisticOverlayViewSql,
+  rebuildOptimisticOverlayView,
   executeOptimisticOperation,
   type OptimisticFieldMapping,
   type OptimisticOperationAction,

--- a/src/optimisticOperations.test.ts
+++ b/src/optimisticOperations.test.ts
@@ -7,6 +7,7 @@ import {
   createOptimisticOperationReconcileSql,
   createOptimisticOperationsTableSql,
   createOptimisticOverlayViewSql,
+  rebuildOptimisticOverlayView,
 } from './optimisticOperations'
 
 const fields = [
@@ -143,6 +144,46 @@ describe('optimistic DuckDB projection', () => {
           ?.toJSON(),
       ).toEqual({
         count: 0n,
+      })
+    } finally {
+      connection.close()
+    }
+  })
+
+  it('skips mappings for optional columns absent from an Arrow snapshot', async () => {
+    const require = createRequire(import.meta.url)
+    const db = await createDuckDB(
+      {
+        mvp: {
+          mainModule: require.resolve('@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm'),
+          mainWorker: '',
+        },
+      },
+      new VoidLogger(),
+      NODE_RUNTIME,
+    )
+    const connection = db.connect()
+    try {
+      connection.query(`CREATE TABLE sparse_source (entity_id VARCHAR, amount DOUBLE)`)
+      connection.query(`INSERT INTO sparse_source VALUES ('trade-1', 10)`)
+      connection.query(createOptimisticOperationsTableSql())
+      connection.query(
+        createOptimisticOperationBeginSql({
+          changeSetId: 'change-1',
+          entityId: 'trade-1',
+          fields: [{ fieldPath: 'amount', value: 12.5 }],
+        }),
+      )
+
+      await rebuildOptimisticOverlayView(connection, {
+        entityColumn: 'entity_id',
+        fields,
+        sourceTable: 'sparse_source',
+        viewName: 'sparse_effective',
+      })
+
+      expect(connection.query(`SELECT amount FROM sparse_effective`).toArray()[0]?.toJSON()).toEqual({
+        amount: 12.5,
       })
     } finally {
       connection.close()

--- a/src/optimisticOperations.ts
+++ b/src/optimisticOperations.ts
@@ -1,9 +1,8 @@
-import type { AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import { context as otelContext, SpanStatusCode } from '@opentelemetry/api'
 import { SeverityNumber } from '@opentelemetry/api-logs'
 import { getLogger, getMeter, getTracer } from './telemetry'
 
-export type OptimisticOperationAction = 'ack' | 'begin' | 'reconcile' | 'reject' | 'unknown'
+export type OptimisticOperationAction = 'ack' | 'begin' | 'overlay' | 'reconcile' | 'reject' | 'unknown'
 
 export interface OptimisticOperationField {
   fieldPath: string
@@ -18,6 +17,10 @@ export interface OptimisticFieldMapping {
 }
 
 const DEFAULT_TABLE = 'optimistic_operations'
+
+type DuckDbQueryConnection = {
+  query(sql: string): unknown | Promise<unknown>
+}
 
 export function createOptimisticOperationsTableSql(tableName = DEFAULT_TABLE): string {
   return `CREATE TABLE IF NOT EXISTS ${identifier(tableName)} (
@@ -94,6 +97,9 @@ export function createOptimisticOverlayViewSql(args: {
   const operations = identifier(args.operationsTable ?? DEFAULT_TABLE)
   const source = identifier(args.sourceTable)
   const entityColumn = identifier(args.entityColumn)
+  if (!args.fields.length) {
+    return `CREATE OR REPLACE VIEW ${identifier(args.viewName)} AS SELECT * FROM ${source};`
+  }
   const values = args.fields
     .map(
       (field, index) =>
@@ -129,6 +135,35 @@ FROM ${source} source
 LEFT JOIN local_values local ON local.entity_id = cast(source.${entityColumn} AS VARCHAR);`
 }
 
+/**
+ * Rebuild an optimistic overlay using only columns present in the current
+ * source table. Arrow snapshots may legitimately omit optional fields.
+ */
+export async function rebuildOptimisticOverlayView(
+  connection: DuckDbQueryConnection,
+  args: {
+    entityColumn: string
+    fields: OptimisticFieldMapping[]
+    operationsTable?: string
+    sourceTable: string
+    viewName: string
+  },
+): Promise<void> {
+  const source = identifier(args.sourceTable)
+  const rows = (await connection.query(`DESCRIBE ${source}`)) as {
+    toArray(): Array<{ toJSON(): { column_name?: unknown } }>
+  }
+  const columns = new Set(
+    rows.toArray().map((row) => String(row.toJSON().column_name)),
+  )
+  const fields = args.fields.filter((field) => columns.has(field.column))
+  await executeOptimisticOperation(
+    connection,
+    'overlay',
+    createOptimisticOverlayViewSql({ ...args, fields }),
+  )
+}
+
 export function createOptimisticOperationReconcileSql(args: {
   entityColumn: string
   fields: OptimisticFieldMapping[]
@@ -152,7 +187,7 @@ ${cases}
 }
 
 export function executeOptimisticOperation(
-  connection: AsyncDuckDBConnection,
+  connection: DuckDbQueryConnection,
   action: OptimisticOperationAction,
   sql: string,
 ): Promise<void> {
@@ -193,7 +228,6 @@ export function executeOptimisticOperation(
 }
 
 function validateMappings(fields: OptimisticFieldMapping[]): void {
-  if (!fields.length) throw new Error('optimistic projection requires field mappings')
   if (new Set(fields.map((field) => field.fieldPath)).size !== fields.length) {
     throw new Error('optimistic field paths must be unique')
   }


### PR DESCRIPTION
Summary: rebuild optimistic DuckDB overlays from the columns actually present in each source snapshot, so optional fields omitted by Arrow data do not cause binder errors. Adds a regression test with a sparse table.