### PR TITLE
feat: expose optimistic change-set lookup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export {
   createOptimisticOperationsTableSql,
   createOptimisticOperationUnknownSql,
   createOptimisticOverlayViewSql,
+  hasOptimisticChangeSet,
   rebuildOptimisticOverlayView,
   executeOptimisticOperation,
   type OptimisticFieldMapping,

--- a/src/optimisticOperations.test.ts
+++ b/src/optimisticOperations.test.ts
@@ -7,6 +7,7 @@ import {
   createOptimisticOperationReconcileSql,
   createOptimisticOperationsTableSql,
   createOptimisticOverlayViewSql,
+  hasOptimisticChangeSet,
   rebuildOptimisticOverlayView,
 } from './optimisticOperations'
 
@@ -169,10 +170,17 @@ describe('optimistic DuckDB projection', () => {
       connection.query(createOptimisticOperationsTableSql())
       connection.query(
         createOptimisticOperationBeginSql({
-          changeSetId: 'change-1',
+          changeSetId: "change-'1",
           entityId: 'trade-1',
           fields: [{ fieldPath: 'amount', value: 12.5 }],
         }),
+      )
+
+      await expect(hasOptimisticChangeSet(connection, { changeSetId: "change-'1" })).resolves.toBe(
+        true,
+      )
+      await expect(hasOptimisticChangeSet(connection, { changeSetId: 'missing' })).resolves.toBe(
+        false,
       )
 
       await rebuildOptimisticOverlayView(connection, {
@@ -182,7 +190,9 @@ describe('optimistic DuckDB projection', () => {
         viewName: 'sparse_effective',
       })
 
-      expect(connection.query(`SELECT amount FROM sparse_effective`).toArray()[0]?.toJSON()).toEqual({
+      expect(
+        connection.query(`SELECT amount FROM sparse_effective`).toArray()[0]?.toJSON(),
+      ).toEqual({
         amount: 12.5,
       })
     } finally {

--- a/src/optimisticOperations.ts
+++ b/src/optimisticOperations.ts
@@ -2,7 +2,8 @@ import { context as otelContext, SpanStatusCode } from '@opentelemetry/api'
 import { SeverityNumber } from '@opentelemetry/api-logs'
 import { getLogger, getMeter, getTracer } from './telemetry'
 
-export type OptimisticOperationAction = 'ack' | 'begin' | 'overlay' | 'reconcile' | 'reject' | 'unknown'
+export type OptimisticOperationAction =
+  'ack' | 'begin' | 'overlay' | 'reconcile' | 'reject' | 'unknown'
 
 export interface OptimisticOperationField {
   fieldPath: string
@@ -86,6 +87,16 @@ export function createOptimisticOperationRejectSql(
   return `DELETE FROM ${identifier(tableName)} WHERE change_set_id = ${string(changeSetId)};`
 }
 
+export async function hasOptimisticChangeSet(
+  connection: DuckDbQueryConnection,
+  args: { changeSetId: string; tableName?: string },
+): Promise<boolean> {
+  const result = (await connection.query(
+    `SELECT count(*) > 0 AS matched FROM ${identifier(args.tableName ?? DEFAULT_TABLE)} WHERE change_set_id = ${string(args.changeSetId)};`,
+  )) as { toArray(): Array<{ toJSON(): { matched?: unknown } }> }
+  return result.toArray()[0]?.toJSON().matched === true
+}
+
 export function createOptimisticOverlayViewSql(args: {
   entityColumn: string
   fields: OptimisticFieldMapping[]
@@ -153,9 +164,7 @@ export async function rebuildOptimisticOverlayView(
   const rows = (await connection.query(`DESCRIBE ${source}`)) as {
     toArray(): Array<{ toJSON(): { column_name?: unknown } }>
   }
-  const columns = new Set(
-    rows.toArray().map((row) => String(row.toJSON().column_name)),
-  )
+  const columns = new Set(rows.toArray().map((row) => String(row.toJSON().column_name)))
   const fields = args.fields.filter((field) => columns.has(field.column))
   await executeOptimisticOperation(
     connection,


### PR DESCRIPTION
## Summary
- add a backend-neutral helper that checks whether an optimistic change set exists
- validate configurable table identifiers and safely quote change-set values using the existing SQL helpers
- export the helper from the package root

## Verification
- 111 tests pass
- TypeScript check passes
- Prettier check passes