### PR TITLE
perf(query): preserve Arrow-backed result rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "state-machine"
   ],
   "dependencies": {
-    "duckdb-wasm-kit": "^0.1.39",
     "pako": "^3.0.1",
     "xstate": "^5.32.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      duckdb-wasm-kit:
-        specifier: ^0.1.39
-        version: 0.1.39(@duckdb/duckdb-wasm@1.33.1-dev45.0)(apache-arrow@21.1.0)(react@19.2.5)
       pako:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1271,13 +1268,6 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  duckdb-wasm-kit@0.1.39:
-    resolution: {integrity: sha512-NeMNKVV642Vc1BszC795p7sIyuD6ntkdjXHh21cgW+wnT9G6qWjv+KjMu0uMz/Y8oXv6q/I8T4JYnZ8wanbFzQ==}
-    peerDependencies:
-      '@duckdb/duckdb-wasm': '*'
-      apache-arrow: '>=15.0.0'
-      react: '>=16.8'
-
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1860,12 +1850,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  react-async-hook@4.0.0:
-    resolution: {integrity: sha512-97lgjFkOcHCTYSrsKBpsXg3iVWM0LnzedB749iP76sb3/8Ouu4nHIkCLEOrQWHVYqrYxjF05NN6GHoXWFkB3Kw==}
-    engines: {node: '>=8', npm: '>=5'}
-    peerDependencies:
-      react: '>=16.8'
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
@@ -3333,13 +3317,6 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  duckdb-wasm-kit@0.1.39(@duckdb/duckdb-wasm@1.33.1-dev45.0)(apache-arrow@21.1.0)(react@19.2.5):
-    dependencies:
-      '@duckdb/duckdb-wasm': 1.33.1-dev45.0
-      apache-arrow: 21.1.0
-      react: 19.2.5
-      react-async-hook: 4.0.0(react@19.2.5)
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3848,10 +3825,6 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
-
-  react-async-hook@4.0.0(react@19.2.5):
-    dependencies:
-      react: 19.2.5
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:

--- a/src/actors/dbQuery.ts
+++ b/src/actors/dbQuery.ts
@@ -1,7 +1,5 @@
 import { AsyncDuckDB, AsyncDuckDBConnection } from '@duckdb/duckdb-wasm'
 import { fromPromise } from 'xstate'
-import { JSONObject } from '../lib/types'
-import { arrowToJSON } from 'duckdb-wasm-kit'
 import { Table } from 'apache-arrow'
 import {
   arrayToObjectMap,
@@ -38,12 +36,8 @@ export const queryDuckDb = fromPromise(
   },
 )
 
-type DuckDbQueryResult =
-  | Record<string, JSONObject>[]
-  | Table<any>
-  | Map<string, any>
-  | Map<string, any[]>
-  | null
+type DuckDbRows = ReturnType<Table<any>['toArray']>
+type DuckDbQueryResult = DuckDbRows | Table<any> | Map<string, any> | Map<string, any[]> | null
 
 export async function duckdbRunQuery(
   input: QueryDbParams & { connection: AsyncDuckDBConnection },
@@ -57,14 +51,10 @@ export async function duckdbRunQuery(
     },
     async (span) => {
       const sql = input.sql as string
-      const raw =
-        input.resultOptions?.type === 'arrow'
-          ? await duckDbExecuteToArrow(input.description, sql, input.connection)
-          : await duckDbExecuteToJson(input.description, sql, input.connection)
+      const table = await duckDbExecuteToArrow(input.description, sql, input.connection)
+      const raw = input.resultOptions?.type === 'arrow' ? table : (table?.toArray() ?? [])
 
-      if (Array.isArray(raw)) {
-        span.setAttribute('result.row_count', raw.length)
-      }
+      span.setAttribute('result.row_count', table?.numRows ?? 0)
 
       const result = formatResult(raw, input.resultOptions)
 
@@ -78,15 +68,15 @@ export async function duckdbRunQuery(
 }
 
 function formatResult(
-  result: Record<string, JSONObject>[] | Table<any> | undefined,
+  result: DuckDbRows | Table<any> | undefined,
   resultOptions?: ResultOptions,
-): Record<string, JSONObject>[] | Table<any> | Map<string, any> | Map<string, any[]> | any | null {
+): DuckDbRows | Table<any> | Map<string, any> | Map<string, any[]> | any | null {
   if (!resultOptions) {
     return result
   }
 
   let transformed:
-    | Record<string, JSONObject>[]
+    | DuckDbRows
     | Table<any>
     | Map<string, any>
     | Map<string, any[]>
@@ -146,19 +136,6 @@ async function duckDbExecuteToArrow(
     console.error(`duckDbError[${description}]`, error)
     return undefined
   }
-}
-
-async function duckDbExecuteToJson(
-  description: string,
-  sqlText: string,
-  connection: AsyncDuckDBConnection,
-): Promise<Record<string, JSONObject>[]> {
-  const response = await duckDbExecuteToArrow(description, sqlText, connection)
-  if (!response) {
-    return []
-  }
-  const jsonResponse = arrowToJSON(response)
-  return jsonResponse
 }
 
 export const beginTransaction = fromPromise(

--- a/tests/actors/dbQuery.test.ts
+++ b/tests/actors/dbQuery.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Binary, Table, vectorFromArray } from 'apache-arrow'
 import { createActor } from 'xstate'
 import {
   duckdbRunQuery,
@@ -9,15 +10,14 @@ import {
   type QueryDbParams,
 } from '../../src/actors/dbQuery'
 
-// Mock duckdb-wasm-kit's arrowToJSON
-vi.mock('duckdb-wasm-kit', () => ({
-  arrowToJSON: vi.fn((table: any) => table._jsonData ?? []),
-}))
-
 // Suppress expected console.error output in error-handling tests
 vi.spyOn(console, 'error').mockImplementation(() => {})
 
-function createMockConnection(queryResult: any = { _jsonData: [] }) {
+function arrowRows(rows: any[]) {
+  return { numRows: rows.length, toArray: () => rows }
+}
+
+function createMockConnection(queryResult: any = arrowRows([])) {
   return {
     query: vi.fn().mockResolvedValue(queryResult),
   } as any
@@ -30,7 +30,7 @@ describe('duckdbRunQuery', () => {
 
   it('returns array result type as-is', async () => {
     const rows = [{ id: 1 }, { id: 2 }]
-    const conn = createMockConnection({ _jsonData: rows })
+    const conn = createMockConnection(arrowRows(rows))
 
     const result = await duckdbRunQuery({
       description: 'test',
@@ -40,11 +40,31 @@ describe('duckdbRunQuery', () => {
     })
 
     expect(result).toEqual(rows)
+    expect((result as any[])[0]).toBe(rows[0])
     expect(conn.query).toHaveBeenCalledWith('SELECT 1')
   })
 
+  it('keeps non-Arrow result rows backed by Arrow vectors', async () => {
+    const payload = Uint8Array.of(1, 2, 3)
+    const table = new Table({
+      id: vectorFromArray(['a']),
+      payload: vectorFromArray([payload], new Binary()),
+    })
+    const conn = createMockConnection(table)
+
+    const result = (await duckdbRunQuery({
+      description: 'typed rows',
+      sql: 'SELECT * FROM t',
+      resultOptions: { type: 'array' },
+      connection: conn,
+    })) as any[]
+
+    expect(result[0]?.[Symbol.toStringTag]).toBe('Row')
+    expect(result[0]?.payload).toEqual(payload)
+  })
+
   it('returns arrow result type directly from query', async () => {
-    const arrowTable = { schema: 'mock-arrow' }
+    const arrowTable = { numRows: 0, schema: 'mock-arrow' }
     const conn = createMockConnection(arrowTable)
 
     const result = await duckdbRunQuery({
@@ -62,7 +82,7 @@ describe('duckdbRunQuery', () => {
       { id: 'a', name: 'Alice' },
       { id: 'b', name: 'Bob' },
     ]
-    const conn = createMockConnection({ _jsonData: rows })
+    const conn = createMockConnection(arrowRows(rows))
 
     const result = await duckdbRunQuery({
       description: 'dict-test',
@@ -80,7 +100,7 @@ describe('duckdbRunQuery', () => {
       { k: 'x', v: 10 },
       { k: 'y', v: 20 },
     ]
-    const conn = createMockConnection({ _jsonData: rows })
+    const conn = createMockConnection(arrowRows(rows))
 
     const result = await duckdbRunQuery({
       description: 'svm-test',
@@ -99,7 +119,7 @@ describe('duckdbRunQuery', () => {
       { cat: 'a', val: 2 },
       { cat: 'b', val: 3 },
     ]
-    const conn = createMockConnection({ _jsonData: rows })
+    const conn = createMockConnection(arrowRows(rows))
 
     const result = await duckdbRunQuery({
       description: 'mm-test',
@@ -114,7 +134,7 @@ describe('duckdbRunQuery', () => {
 
   it('returns firstvalue result type', async () => {
     const rows = [{ count: 42 }]
-    const conn = createMockConnection({ _jsonData: rows })
+    const conn = createMockConnection(arrowRows(rows))
 
     const result = await duckdbRunQuery({
       description: 'fv-test',
@@ -131,7 +151,7 @@ describe('duckdbRunQuery', () => {
       { a: 1, b: 2 },
       { a: 3, b: 4 },
     ]
-    const conn = createMockConnection({ _jsonData: rows })
+    const conn = createMockConnection(arrowRows(rows))
 
     const result = await duckdbRunQuery({
       description: 'fr-test',
@@ -145,7 +165,7 @@ describe('duckdbRunQuery', () => {
 
   it('invokes callback instead of returning when callback is provided', async () => {
     const rows = [{ id: 1 }]
-    const conn = createMockConnection({ _jsonData: rows })
+    const conn = createMockConnection(arrowRows(rows))
     const callback = vi.fn()
 
     const result = await duckdbRunQuery({
@@ -162,8 +182,7 @@ describe('duckdbRunQuery', () => {
 
   it('returns empty array when connection.query returns undefined', async () => {
     const conn = createMockConnection(undefined)
-    // When arrow query returns undefined, duckDbExecuteToJson returns []
-    // For arrow type, the result is undefined itself
+    // Non-Arrow result types fall back to an empty row array.
 
     const result = await duckdbRunQuery({
       description: 'empty-test',
@@ -192,7 +211,7 @@ describe('duckdbRunQuery', () => {
   })
 
   it('throws for unsupported result type', async () => {
-    const conn = createMockConnection({ _jsonData: [] })
+    const conn = createMockConnection(arrowRows([]))
 
     await expect(
       duckdbRunQuery({
@@ -205,8 +224,7 @@ describe('duckdbRunQuery', () => {
   })
 
   it('returns empty map when query returns no rows for dictionary type', async () => {
-    // arrowToJSON mock returns [] when _jsonData is undefined
-    const conn = createMockConnection({ schema: 'not-an-array' })
+    const conn = createMockConnection(arrowRows([]))
 
     const result = await duckdbRunQuery({
       description: 'empty-dict',
@@ -243,7 +261,7 @@ describe('queryDuckDb actor', () => {
 
   it('resolves a Promise connection before running query', async () => {
     const rows = [{ id: 1 }]
-    const mockConn = createMockConnection({ _jsonData: rows })
+    const mockConn = createMockConnection(arrowRows(rows))
 
     const actor = createActor(queryDuckDb, {
       input: {
@@ -267,7 +285,7 @@ describe('queryDuckDb actor', () => {
 
   it('accepts a non-Promise connection directly', async () => {
     const rows = [{ id: 2 }]
-    const mockConn = createMockConnection({ _jsonData: rows })
+    const mockConn = createMockConnection(arrowRows(rows))
 
     const actor = createActor(queryDuckDb, {
       input: {


### PR DESCRIPTION
## Summary
- keep non-table query rows backed by Apache Arrow vectors
- build existing array and map result shapes from StructRow proxies
- remove the row-to-JSON materialization dependency
- retain direct Table results for the explicit arrow result type

## Verification
- pnpm test
- pnpm lint