### PR TITLE
fix: reject duplicate Arrow fields

### DIFF
--- a/src/actors/dbQuery.ts
+++ b/src/actors/dbQuery.ts
@@ -52,6 +52,7 @@ export async function duckdbRunQuery(
     async (span) => {
       const sql = input.sql as string
       const table = await duckDbExecuteToArrow(input.description, sql, input.connection)
+      if (table) assertUniqueFieldNames(table, input.description)
       const raw = input.resultOptions?.type === 'arrow' ? table : (table?.toArray() ?? [])
 
       span.setAttribute('result.row_count', table?.numRows ?? 0)
@@ -65,6 +66,14 @@ export async function duckdbRunQuery(
       return result
     },
   )
+}
+
+function assertUniqueFieldNames(table: Table<any>, description: string): void {
+  const names = table.schema?.fields?.map((field) => field.name) ?? []
+  const duplicates = [...new Set(names.filter((name, index) => names.indexOf(name) !== index))]
+  if (duplicates.length) {
+    throw new Error(`Query "${description}" returned duplicate Arrow fields: ${duplicates.join(', ')}`)
+  }
 }
 
 function formatResult(

--- a/tests/actors/dbQuery.test.ts
+++ b/tests/actors/dbQuery.test.ts
@@ -63,6 +63,24 @@ describe('duckdbRunQuery', () => {
     expect(result[0]?.payload).toEqual(payload)
   })
 
+  it('rejects duplicate fields before Arrow creates invalid row proxies', async () => {
+    const table = {
+      numRows: 1,
+      schema: { fields: [{ name: 'id' }, { name: 'id' }] },
+      toArray: vi.fn(),
+    }
+
+    await expect(
+      duckdbRunQuery({
+        description: 'duplicate fields',
+        sql: 'SELECT *',
+        resultOptions: { type: 'array' },
+        connection: createMockConnection(table),
+      }),
+    ).rejects.toThrow('Query "duplicate fields" returned duplicate Arrow fields: id')
+    expect(table.toArray).not.toHaveBeenCalled()
+  })
+
   it('returns arrow result type directly from query', async () => {
     const arrowTable = { numRows: 0, schema: 'mock-arrow' }
     const conn = createMockConnection(arrowTable)


### PR DESCRIPTION
## Summary
- validate DuckDB Arrow query schemas before returning results
- reject duplicate field names with the query description and offending names
- prevent invalid Arrow row proxies from escaping the query boundary

## Tests
- pnpm test
- pnpm lint