### PR TITLE
fix: project configured multimap values

### DIFF
--- a/src/actors/dbQuery.ts
+++ b/src/actors/dbQuery.ts
@@ -101,7 +101,7 @@ function formatResult(
     if (!Array.isArray(result)) {
       throw new Error('Result must be an array for multimap transformation')
     }
-    transformed = arrayToObjectMultiMap(result, resultOptions.key!)
+    transformed = arrayToObjectMultiMap(result, resultOptions.key!, resultOptions.value)
   } else if (resultOptions.type === 'dictionary') {
     if (!Array.isArray(result)) {
       throw new Error('Result must be an array for dictionary transformation')

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,7 +14,7 @@ export function arrayToObjectMap(array: any[], key: string): Map<string, any> {
   return map
 }
 
-export function arrayToObjectMultiMap(array: any[], key: string): Map<string, any[]> {
+export function arrayToObjectMultiMap(array: any[], key: string, value?: string): Map<string, any[]> {
   const map = new Map<string, any[]>()
   array.forEach((item) => {
     const keyValue = item[key]
@@ -24,7 +24,7 @@ export function arrayToObjectMultiMap(array: any[], key: string): Map<string, an
     if (!map.has(keyValue)) {
       map.set(keyValue, [])
     }
-    map.get(keyValue)!.push(item)
+    map.get(keyValue)!.push(value === undefined ? item : item[value])
   })
   return map
 }

--- a/tests/actors/dbQuery.test.ts
+++ b/tests/actors/dbQuery.test.ts
@@ -150,6 +150,24 @@ describe('duckdbRunQuery', () => {
     expect((result as Map<string, any[]>).get('a')).toHaveLength(2)
   })
 
+  it('projects multimap values when a value field is configured', async () => {
+    const rows = [
+      { cat: 'a', val: 1 },
+      { cat: 'a', val: 2 },
+      { cat: 'b', val: 3 },
+    ]
+    const conn = createMockConnection(arrowRows(rows))
+
+    const result = await duckdbRunQuery({
+      description: 'mm-value-test',
+      sql: 'SELECT *',
+      resultOptions: { type: 'multimap', key: 'cat', value: 'val' },
+      connection: conn,
+    })
+
+    expect((result as Map<string, number[]>).get('a')).toEqual([1, 2])
+  })
+
   it('returns firstvalue result type', async () => {
     const rows = [{ count: 42 }]
     const conn = createMockConnection(arrowRows(rows))


### PR DESCRIPTION
## Summary

- honor `resultOptions.value` for multimap results
- retain complete-row grouping when no value field is configured
- cover both multimap forms with tests

## Root cause

The multimap formatter accepted a value field but ignored it, so callers requesting value arrays received complete row objects.

## Verification

- `pnpm test`
- `pnpm lint`